### PR TITLE
fix(segments): should be stable once `isFinalized`

### DIFF
--- a/packages/react-user-media/package.json
+++ b/packages/react-user-media/package.json
@@ -17,7 +17,7 @@
     "name": "bengreenier",
     "url": "https://github.com/bengreenier"
   },
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "licenses": [
     {


### PR DESCRIPTION
Previously the segments could receive one final update after `isFinalized` became `true` - this could cause consumer effects that read segments to run twice, even if guarded with `isFinalized` to run twice.

This PR fixes this behavior, such that with a guard such a consumer effect would run only once.