### PR TITLE
fix(recorder): harden lifecycle and state model

### DIFF
--- a/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
@@ -1,7 +1,171 @@
 import "@testing-library/jest-dom";
 import { userEvent } from "@vitest/browser/context";
-import { render, screen, act, waitFor } from "@testing-library/react";
+import { render, screen, act, cleanup, waitFor } from "@testing-library/react";
 import { useMedia, useMediaRecorder, VideoPlayer } from "../";
+
+const mockStream = new MediaStream();
+
+class MockMediaRecorder extends EventTarget {
+  static instances: MockMediaRecorder[] = [];
+
+  readonly startCalls: unknown[][] = [];
+  readonly media: MediaStream;
+  readonly options?: MediaRecorderOptions;
+  state: RecordingState = "inactive";
+  stopCalls = 0;
+
+  constructor(media: MediaStream, options?: MediaRecorderOptions) {
+    super();
+
+    this.media = media;
+    this.options = options;
+    MockMediaRecorder.instances.push(this);
+  }
+
+  start(...args: unknown[]) {
+    this.startCalls.push(args);
+    this.state = "recording";
+    this.dispatchEvent(new Event("start"));
+  }
+
+  stop() {
+    if (this.state === "inactive") {
+      return;
+    }
+
+    this.stopCalls += 1;
+    this.state = "inactive";
+    this.dispatchEvent(new Event("stop"));
+  }
+
+  dispatchData(data: Blob) {
+    this.dispatchEvent(new BlobEvent("dataavailable", { data }));
+  }
+
+  dispatchRecorderError() {
+    this.dispatchEvent(new Event("error"));
+  }
+}
+
+function RecorderLifecycleTestComponent() {
+  const recorder = useMediaRecorder();
+
+  return (
+    <>
+      <button onClick={() => act(() => recorder.startRecording(mockStream))}>
+        Start
+      </button>
+      <button
+        onClick={() =>
+          act(() => recorder.startRecording(mockStream, { timeslice: 250 }))
+        }
+      >
+        Start With Timeslice
+      </button>
+      <button onClick={() => act(() => recorder.stopRecording())}>Stop</button>
+      <p data-testid="is-error">{String(recorder.isError)}</p>
+      <p data-testid="is-finalized">{String(recorder.isFinalized)}</p>
+      <p data-testid="is-recording">{String(recorder.isRecording)}</p>
+      <p data-testid="segments-length">{recorder.segments.length}</p>
+    </>
+  );
+}
+
+describe("useMediaRecorder lifecycle", () => {
+  const originalMediaRecorder = globalThis.MediaRecorder;
+
+  beforeEach(() => {
+    MockMediaRecorder.instances = [];
+    Object.defineProperty(globalThis, "MediaRecorder", {
+      configurable: true,
+      writable: true,
+      value: MockMediaRecorder as unknown as typeof MediaRecorder,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    Object.defineProperty(globalThis, "MediaRecorder", {
+      configurable: true,
+      writable: true,
+      value: originalMediaRecorder,
+    });
+  });
+
+  test("starts from idle state", async () => {
+    render(<RecorderLifecycleTestComponent />);
+
+    expect(await screen.findByTestId("is-error")).toHaveTextContent("false");
+    expect(screen.getByTestId("is-recording")).toHaveTextContent("false");
+    expect(screen.getByTestId("is-finalized")).toHaveTextContent("false");
+    expect(screen.getByTestId("segments-length")).toHaveTextContent("0");
+  });
+
+  test("uses the browser default timeslice unless one is provided", async () => {
+    render(<RecorderLifecycleTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start"));
+
+    expect(MockMediaRecorder.instances[0]?.startCalls[0]).toEqual([]);
+
+    await userEvent.click(await screen.findByText("Start With Timeslice"));
+
+    expect(MockMediaRecorder.instances[1]?.startCalls[0]).toEqual([250]);
+  });
+
+  test("cleans up the previous recorder when restarted", async () => {
+    render(<RecorderLifecycleTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start"));
+    const firstRecorder = MockMediaRecorder.instances[0];
+
+    await userEvent.click(await screen.findByText("Start"));
+    const secondRecorder = MockMediaRecorder.instances[1];
+
+    expect(firstRecorder.stopCalls).toBe(1);
+
+    act(() => {
+      firstRecorder.dispatchData(new Blob(["old"]));
+      secondRecorder.dispatchData(new Blob(["new"]));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("segments-length")).toHaveTextContent("1"),
+    );
+  });
+
+  test("clears recorder errors when a new recording starts", async () => {
+    render(<RecorderLifecycleTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start"));
+
+    act(() => {
+      MockMediaRecorder.instances[0]?.dispatchRecorderError();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("is-error")).toHaveTextContent("true"),
+    );
+
+    await userEvent.click(await screen.findByText("Start"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("is-error")).toHaveTextContent("false"),
+    );
+  });
+
+  test("finalizes even when stop yields no segments", async () => {
+    render(<RecorderLifecycleTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start"));
+    await userEvent.click(await screen.findByText("Stop"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("is-finalized")).toHaveTextContent("true"),
+    );
+    expect(screen.getByTestId("segments-length")).toHaveTextContent("0");
+  });
+});
 
 function UserMediaTestComponent() {
   const { isReady, media, request } = useMedia("user");
@@ -50,12 +214,7 @@ test("records userMedia video", async () => {
 
   await userEvent.click(await screen.findByText("Start Recording"));
 
-  await waitFor(
-    () => {
-      expect(player.played.length).toBeGreaterThan(0);
-    },
-    { timeout: 5000 },
-  );
+  await new Promise((resolve) => setTimeout(resolve, 200));
 
   await userEvent.click(await screen.findByText("Stop Recording"));
 
@@ -63,5 +222,6 @@ test("records userMedia video", async () => {
     "media-recorded-length",
   );
 
+  expect(player.played.length).toBeGreaterThan(0);
   expect(Number(recordedLengthEl.innerText).valueOf()).toBeGreaterThan(0);
 });

--- a/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
@@ -9,6 +9,7 @@ class MockMediaRecorder extends EventTarget {
   static instances: MockMediaRecorder[] = [];
 
   readonly startCalls: unknown[][] = [];
+  readonly listenerCounts = new Map<string, number>();
   readonly media: MediaStream;
   readonly options?: MediaRecorderOptions;
   state: RecordingState = "inactive";
@@ -20,6 +21,27 @@ class MockMediaRecorder extends EventTarget {
     this.media = media;
     this.options = options;
     MockMediaRecorder.instances.push(this);
+  }
+
+  override addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ) {
+    this.listenerCounts.set(type, (this.listenerCounts.get(type) ?? 0) + 1);
+    super.addEventListener(type, callback, options);
+  }
+
+  override removeEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: EventListenerOptions | boolean,
+  ) {
+    this.listenerCounts.set(
+      type,
+      Math.max((this.listenerCounts.get(type) ?? 0) - 1, 0),
+    );
+    super.removeEventListener(type, callback, options);
   }
 
   start(...args: unknown[]) {
@@ -134,6 +156,51 @@ describe("useMediaRecorder lifecycle", () => {
     );
   });
 
+  test("ignores async custom dataAvailableHandler callbacks from previous sessions after restart", async () => {
+    const deferredCallbacks: (() => void)[] = [];
+
+    function AsyncHandlerTestComponent() {
+      const recorder = useMediaRecorder();
+
+      return (
+        <>
+          <button
+            onClick={() =>
+              act(() =>
+                recorder.startRecording(mockStream, {
+                  dataAvailableHandler(ev, callback) {
+                    deferredCallbacks.push(() =>
+                      callback((current) => current.concat(ev.data)),
+                    );
+                  },
+                }),
+              )
+            }
+          >
+            Start Async
+          </button>
+          <p data-testid="segments-length">{recorder.segments.length}</p>
+        </>
+      );
+    }
+
+    render(<AsyncHandlerTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start Async"));
+    act(() => {
+      MockMediaRecorder.instances[0]?.dispatchData(new Blob(["old"]));
+    });
+    expect(deferredCallbacks).toHaveLength(1);
+
+    await userEvent.click(await screen.findByText("Start Async"));
+    expect(MockMediaRecorder.instances).toHaveLength(2);
+    expect(screen.getByTestId("segments-length")).toHaveTextContent("0");
+
+    act(() => deferredCallbacks[0]());
+
+    expect(screen.getByTestId("segments-length")).toHaveTextContent("0");
+  });
+
   test("clears recorder errors when a new recording starts", async () => {
     render(<RecorderLifecycleTestComponent />);
 
@@ -152,6 +219,45 @@ describe("useMediaRecorder lifecycle", () => {
     await waitFor(() =>
       expect(screen.getByTestId("is-error")).toHaveTextContent("false"),
     );
+  });
+
+  test("ignores late errors from previous recorder sessions after restart", async () => {
+    function LateErrorTestComponent() {
+      const recorder = useMediaRecorder();
+
+      return (
+        <>
+          <button onClick={() => act(() => recorder.startRecording(mockStream))}>
+            Start
+          </button>
+          <button
+            onClick={() => {
+              const previousRecorder = MockMediaRecorder.instances.at(-1);
+              act(() => {
+                recorder.startRecording(mockStream);
+                previousRecorder?.dispatchRecorderError();
+              });
+            }}
+          >
+            Restart With Late Error
+          </button>
+          <p data-testid="is-error">{String(recorder.isError)}</p>
+        </>
+      );
+    }
+
+    render(<LateErrorTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start"));
+    await waitFor(() =>
+      expect(
+        MockMediaRecorder.instances[0]?.listenerCounts.get("error"),
+      ).toBeGreaterThan(0),
+    );
+
+    await userEvent.click(await screen.findByText("Restart With Late Error"));
+
+    expect(screen.getByTestId("is-error")).toHaveTextContent("false");
   });
 
   test("finalizes even when stop yields no segments", async () => {

--- a/packages/react-user-media/src/hooks/use-media-recorder.ts
+++ b/packages/react-user-media/src/hooks/use-media-recorder.ts
@@ -1,6 +1,5 @@
 import {
   useState,
-  useMemo,
   useCallback,
   useSyncExternalStore,
   useEffect,
@@ -15,15 +14,15 @@ export interface RecorderOptions extends MediaRecorderOptions {
   /**
    * The number of milliseconds to record into each `Blob`.
    *
-   * If this parameter isn't included, the entire media duration is recorded
-   * into a single `Blob` unless the `requestData()` method is called to
-   * obtain the `Blob` and trigger the creation of a new `Blob` into which
-   * the media continues to be recorded.
+   * If this parameter isn't included, the browser default behavior is used:
+   * the entire media duration is recorded into a single `Blob` unless the
+   * `requestData()` method is called to obtain the `Blob` and trigger the
+   * creation of a new `Blob` into which the media continues to be recorded.
    */
   timeslice?: number;
 
   /**
-   * A custom handler for the `datavailable` event.
+   * A custom handler for the `dataavailable` event.
    *
    * Note: This is for advanced use-cases only. You probably don't need to modify the default handler.
    * @param ev - the event
@@ -60,6 +59,11 @@ interface RecorderStateBase {
    * See {@link startTime}.
    */
   isRecording: boolean;
+
+  /**
+   * Indicates that recording is currently paused.
+   */
+  isPaused: boolean;
 
   /**
    * Indicates that {@link segments} are ready for consumption.
@@ -107,6 +111,30 @@ interface RecorderStateBase {
    * Stops recording `media` with this recorder.
    */
   stopRecording(): void;
+
+  /**
+   * Pauses recording `media` with this recorder.
+   */
+  pauseRecording(): void;
+
+  /**
+   * Resumes recording `media` with this recorder.
+   */
+  resumeRecording(): void;
+}
+
+/**
+ * The idle state of the recorder.
+ */
+interface RecorderIdleState extends RecorderStateBase {
+  isError: false;
+  isRecording: false;
+  isPaused: false;
+  isFinalized: false;
+  error: null;
+  startTime: null;
+  endTime: null;
+  segments: [];
 }
 
 /**
@@ -115,11 +143,12 @@ interface RecorderStateBase {
 interface RecorderErrorState extends RecorderStateBase {
   isError: true;
   isRecording: false;
+  isPaused: false;
   isFinalized: false;
   error: Error;
-  startTime: null;
-  endTime: null;
-  segments: [];
+  startTime: DOMHighResTimeStamp | null;
+  endTime: DOMHighResTimeStamp | null;
+  segments: Blob[];
 }
 
 /**
@@ -128,11 +157,26 @@ interface RecorderErrorState extends RecorderStateBase {
 interface RecorderRecordingState extends RecorderStateBase {
   isError: false;
   isRecording: true;
+  isPaused: false;
   isFinalized: false;
   error: null;
   startTime: DOMHighResTimeStamp;
   endTime: null;
-  segments: [];
+  segments: Blob[];
+}
+
+/**
+ * The paused state of the recorder.
+ */
+interface RecorderPausedState extends RecorderStateBase {
+  isError: false;
+  isRecording: false;
+  isPaused: true;
+  isFinalized: false;
+  error: null;
+  startTime: DOMHighResTimeStamp;
+  endTime: null;
+  segments: Blob[];
 }
 
 /**
@@ -141,6 +185,7 @@ interface RecorderRecordingState extends RecorderStateBase {
 interface RecorderFinalizedState extends RecorderStateBase {
   isError: false;
   isRecording: false;
+  isPaused: false;
   isFinalized: true;
   error: null;
   startTime: DOMHighResTimeStamp;
@@ -152,8 +197,10 @@ interface RecorderFinalizedState extends RecorderStateBase {
  * The state of the recorder.
  */
 export type RecorderState =
+  | RecorderIdleState
   | RecorderErrorState
   | RecorderRecordingState
+  | RecorderPausedState
   | RecorderFinalizedState;
 
 /**
@@ -161,85 +208,140 @@ export type RecorderState =
  * @returns See {@link RecorderState} for more information.
  */
 export function useMediaRecorder(): RecorderState {
-  // we need _both_ a referentially stable version of MediaRecorder and a mutable version
-  // so that we can have stable start/stop functions, but also dynamic state updates
   const recorderRef = useRef<MediaRecorder | null>(null);
-  const [isRecorderDirty, setIsRecorderDirty] = useState<boolean>(false);
-  const recorder = useMemo(() => {
-    if (isRecorderDirty) setIsRecorderDirty(false);
-
-    return recorderRef.current ?? undefined;
-  }, [recorderRef, isRecorderDirty]);
+  const cleanupRecorderRef = useRef<(() => void) | null>(null);
+  const sessionIdRef = useRef(0);
+  const [recorder, setRecorder] = useState<MediaRecorder | null>(null);
 
   const recorderState = useMediaRecorderState(recorder);
-  const isRecording = useMemo(
-    () => recorderState === "recording",
-    [recorderState],
-  );
 
-  const error = useMediaRecorderError(recorder);
-  const isError = useMemo(() => error !== null, [error]);
+  const [error, setError] = useMediaRecorderError(recorder);
+  const isError = error !== null;
+  const isRecording = !isError && recorderState === "recording";
+  const isPaused = !isError && recorderState === "paused";
 
   const [startTime, setStartTime] = useState<DOMHighResTimeStamp | null>(null);
   const [endTime, setEndTime] = useState<DOMHighResTimeStamp | null>(null);
 
   const [segments, setSegments] = useState<Blob[]>([]);
-  const isFinalized = useMemo(
-    () =>
-      segments.length > 0 && recorderState === "inactive" && endTime !== null,
-    [segments, recorderState, endTime],
+  const isFinalized =
+    !isError && recorderState === "inactive" && endTime !== null;
+
+  const cleanupCurrentRecorder = useCallback(
+    function cleanupCurrentRecorder() {
+      sessionIdRef.current += 1;
+
+      cleanupRecorderRef.current?.();
+      cleanupRecorderRef.current = null;
+      recorderRef.current = null;
+    },
+    [],
   );
 
   const startRecording = useCallback(function startRecordingMedia(
     media: MediaStream,
     options?: RecorderOptions,
   ) {
-    const { timeslice, dataAvailableHandler, ...recorderOptions } = {
-      timeslice: 30 * 1000 /* 30s */,
-      dataAvailableHandler: (
+    cleanupCurrentRecorder();
+
+    const {
+      timeslice,
+      dataAvailableHandler = (
         ev: BlobEvent,
         callback: (value: React.SetStateAction<Blob[]>) => void,
       ) => {
         callback((current) => current.concat(ev.data));
       },
-      ...options,
-    };
+      ...recorderOptions
+    } = options ?? {};
 
     const recorder = new MediaRecorder(media, recorderOptions);
+    const sessionId = sessionIdRef.current;
 
-    recorder.addEventListener("dataavailable", function onDataAvailable(ev) {
+    const onDataAvailable = function onDataAvailable(ev: BlobEvent) {
+      if (sessionIdRef.current !== sessionId) {
+        return;
+      }
+
       dataAvailableHandler(ev, setSegments);
-    });
+    };
 
+    recorder.addEventListener("dataavailable", onDataAvailable);
+
+    cleanupRecorderRef.current = function cleanupRecorder() {
+      recorder.removeEventListener("dataavailable", onDataAvailable);
+
+      if (recorder.state !== "inactive") {
+        recorder.stop();
+      }
+    };
+
+    setError(null);
     setSegments([]);
     setEndTime(null);
 
     const startTime = performance.now();
-    recorder.start(timeslice);
+
+    if (timeslice === undefined) {
+      recorder.start();
+    } else {
+      recorder.start(timeslice);
+    }
 
     setStartTime(startTime);
 
     recorderRef.current = recorder;
-    setIsRecorderDirty(true);
-  }, []);
+    setRecorder(recorder);
+  }, [cleanupCurrentRecorder, setError]);
 
   const stopRecording = useCallback(function stopRecordingMedia() {
+    const recorder = recorderRef.current;
+
+    if (!recorder || recorder.state === "inactive") {
+      return;
+    }
+
+    const sessionId = sessionIdRef.current;
     const endTime = performance.now();
 
-    recorderRef.current?.addEventListener(
+    recorder.addEventListener(
       "stop",
       function onStopCompleted() {
+        if (sessionIdRef.current !== sessionId) {
+          return;
+        }
+
         setEndTime(endTime);
       },
       { once: true },
     );
 
-    recorderRef.current?.stop();
+    recorder.stop();
   }, []);
+
+  const pauseRecording = useCallback(function pauseRecordingMedia() {
+    if (recorderRef.current?.state === "recording") {
+      recorderRef.current.pause();
+    }
+  }, []);
+
+  const resumeRecording = useCallback(function resumeRecordingMedia() {
+    if (recorderRef.current?.state === "paused") {
+      recorderRef.current.resume();
+    }
+  }, []);
+
+  useEffect(
+    function cleanupRecorderOnUnmount() {
+      return cleanupCurrentRecorder;
+    },
+    [cleanupCurrentRecorder],
+  );
 
   const state = {
     isError,
     isRecording,
+    isPaused,
     isFinalized,
     error,
     segments,
@@ -247,10 +349,12 @@ export function useMediaRecorder(): RecorderState {
     endTime,
     startRecording,
     stopRecording,
+    pauseRecording,
+    resumeRecording,
   } satisfies ShallowShapeOf<RecorderState>;
 
   // we cast, as it isn't worth the runtime cost to check that this
-  // lines up with each condition (isError, isLoading, isReady)
+  // lines up with each condition.
   return state as RecorderState;
 }
 
@@ -259,7 +363,7 @@ export function useMediaRecorder(): RecorderState {
  * @param recorder the {@link MediaRecorder} to observe.
  * @returns The `recorder` state.
  */
-function useMediaRecorderState(recorder: MediaRecorder | undefined) {
+function useMediaRecorderState(recorder: MediaRecorder | null) {
   return useSyncExternalStore(
     useCallback(
       function subscribe(callback) {
@@ -279,7 +383,7 @@ function useMediaRecorderState(recorder: MediaRecorder | undefined) {
     ),
     useCallback(
       function getSnapshot() {
-        return recorder?.state ?? "unavailable";
+        return recorder?.state ?? "inactive";
       },
       [recorder],
     ),
@@ -291,24 +395,28 @@ function useMediaRecorderState(recorder: MediaRecorder | undefined) {
  * @param recorder the {@link MediaRecorder} to observe.
  * @returns The `error`, if any.
  */
-function useMediaRecorderError(recorder: MediaRecorder | undefined) {
+function useMediaRecorderError(recorder: MediaRecorder | null) {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(
     function observeRecorderError() {
-      if (recorder) {
-        const onError = () => {
-          setError(new Error(`MediaRecorder encountered an unknown error.`));
-        };
-        recorder.addEventListener("error", onError);
+      setError(null);
 
-        return function teardown() {
-          recorder.removeEventListener("error", onError);
-        };
+      if (!recorder) {
+        return;
       }
+
+      const onError = () => {
+        setError(new Error(`MediaRecorder encountered an unknown error.`));
+      };
+      recorder.addEventListener("error", onError);
+
+      return function teardown() {
+        recorder.removeEventListener("error", onError);
+      };
     },
     [recorder],
   );
 
-  return error;
+  return [error, setError] as const;
 }

--- a/packages/react-user-media/src/hooks/use-media-recorder.ts
+++ b/packages/react-user-media/src/hooks/use-media-recorder.ts
@@ -215,7 +215,7 @@ export function useMediaRecorder(): RecorderState {
 
   const recorderState = useMediaRecorderState(recorder);
 
-  const [error, setError] = useMediaRecorderError(recorder);
+  const [error, setError] = useMediaRecorderError(recorder, sessionIdRef);
   const isError = error !== null;
   const isRecording = !isError && recorderState === "recording";
   const isPaused = !isError && recorderState === "paused";
@@ -263,7 +263,13 @@ export function useMediaRecorder(): RecorderState {
         return;
       }
 
-      dataAvailableHandler(ev, setSegments);
+      dataAvailableHandler(ev, function setSegmentsForSession(value) {
+        if (sessionIdRef.current !== sessionId) {
+          return;
+        }
+
+        setSegments(value);
+      });
     };
 
     recorder.addEventListener("dataavailable", onDataAvailable);
@@ -395,28 +401,62 @@ function useMediaRecorderState(recorder: MediaRecorder | null) {
  * @param recorder the {@link MediaRecorder} to observe.
  * @returns The `error`, if any.
  */
-function useMediaRecorderError(recorder: MediaRecorder | null) {
-  const [error, setError] = useState<Error | null>(null);
+function useMediaRecorderError(
+  recorder: MediaRecorder | null,
+  sessionIdRef: React.MutableRefObject<number>,
+) {
+  const [errorState, setErrorState] = useState<{
+    error: Error;
+    sessionId: number;
+  } | null>(null);
 
-  useEffect(
-    function observeRecorderError() {
-      setError(null);
-
-      if (!recorder) {
+  const setError = useCallback(
+    function setCurrentSessionError(error: Error | null) {
+      if (error === null) {
+        setErrorState(null);
         return;
       }
 
+      setErrorState({ error, sessionId: sessionIdRef.current });
+    },
+    [sessionIdRef],
+  );
+
+  useEffect(
+    function observeRecorderError() {
+      const sessionId = sessionIdRef.current;
+      let isCurrentSubscription = true;
+
+      setErrorState(null);
+
+      if (!recorder) {
+        return function teardown() {
+          isCurrentSubscription = false;
+        };
+      }
+
       const onError = () => {
-        setError(new Error(`MediaRecorder encountered an unknown error.`));
+        if (!isCurrentSubscription || sessionIdRef.current !== sessionId) {
+          return;
+        }
+
+        setErrorState({
+          error: new Error(`MediaRecorder encountered an unknown error.`),
+          sessionId,
+        });
       };
       recorder.addEventListener("error", onError);
 
       return function teardown() {
+        isCurrentSubscription = false;
         recorder.removeEventListener("error", onError);
       };
     },
-    [recorder],
+    [recorder, sessionIdRef],
   );
+
+  const error =
+    errorState?.sessionId === sessionIdRef.current ? errorState.error : null;
 
   return [error, setError] as const;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens `useMediaRecorder` lifecycle/state model and session-safety follow-ups.

## Changes

- Restart cleans up previous recorder; idle/paused model; `Blob[]` while recording
- Browser-default timeslice when omitted (**breaking** vs old implicit 30s)
- Finalize on stop even with empty segments; unmount cleanup
- **Session-guarded `setSegments` callback** for custom/async `dataAvailableHandler`
- **Session-aware error handling** so late errors from old recorders cannot re-poison a new session
- Tests for restart, async handler after restart, late error after restart
- CI pin commits (rebase after #12)

## Test plan

- [x] Package tests + build
- [ ] CI green

## Breaking

Callers that relied on default 30s chunks must pass `{ timeslice: 30000 }`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

