### PR TITLE
fix(players): VideoPlayer docs and srcObject cleanup

### DIFF
--- a/packages/react-user-media/src/components/AudioPlayer.spec.tsx
+++ b/packages/react-user-media/src/components/AudioPlayer.spec.tsx
@@ -29,3 +29,26 @@ test("plays back userMedia audio", async () => {
 
   expect(player.played.length).toBeGreaterThan(0);
 });
+
+test("clears srcObject on unmount", () => {
+  const stream = new MediaStream();
+  let element: HTMLAudioElement | null = null;
+
+  const { unmount } = render(
+    <AudioPlayer
+      ref={(el) => {
+        if (el) {
+          element = el;
+        }
+      }}
+      media={stream}
+    />,
+  );
+
+  expect(element).not.toBeNull();
+  expect(element!.srcObject).toBe(stream);
+
+  unmount();
+
+  expect(element!.srcObject).toBeNull();
+});

--- a/packages/react-user-media/src/components/AudioPlayer.spec.tsx
+++ b/packages/react-user-media/src/components/AudioPlayer.spec.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { userEvent } from "@vitest/browser/context";
 import { render, screen, act } from "@testing-library/react";
 import { AudioPlayer } from "./AudioPlayer";
+import { getHostRefCallback } from "./media-player-test-utils";
 import { useMedia } from "../";
 
 function UserMediaTestComponent() {
@@ -51,4 +52,20 @@ test("clears srcObject on unmount", () => {
   unmount();
 
   expect(element!.srcObject).toBeNull();
+});
+
+test("clears srcObject on previous element when DOM element is replaced", () => {
+  const stream = new MediaStream();
+  const { container } = render(<AudioPlayer media={stream} />);
+  const previousElement = container.querySelector("audio")!;
+  const nextElement = document.createElement("audio");
+
+  expect(previousElement.srcObject).toBe(stream);
+
+  act(() => {
+    getHostRefCallback(previousElement)(nextElement);
+  });
+
+  expect(previousElement.srcObject).toBeNull();
+  expect(nextElement.srcObject).toBe(stream);
 });

--- a/packages/react-user-media/src/components/AudioPlayer.tsx
+++ b/packages/react-user-media/src/components/AudioPlayer.tsx
@@ -2,6 +2,7 @@ import {
   DetailedHTMLProps,
   forwardRef,
   useCallback,
+  useRef,
   AudioHTMLAttributes,
 } from "react";
 
@@ -14,7 +15,7 @@ type AudioElementProps = DetailedHTMLProps<
  * React props for {@link AudioPlayer}.
  */
 export interface AudioPlayerProps
-  extends Omit<AudioElementProps, keyof Pick<AudioElementProps, "src">> {
+  extends Omit<AudioElementProps, "src" | "srcObject"> {
   /**
    * The {@link MediaProvider} instance to play.
    */
@@ -29,18 +30,26 @@ export interface AudioPlayerProps
 export const AudioPlayer = forwardRef<HTMLAudioElement, AudioPlayerProps>(
   function AudioPlayer(props, ref) {
     const { media, ...rest } = props;
+    const elementRef = useRef<HTMLAudioElement | null>(null);
 
     const setRef = useCallback(
-      (element: HTMLAudioElement) => {
+      (element: HTMLAudioElement | null) => {
         if (typeof ref === "function") {
-          // Pass the DOM element to the callback ref
           ref(element);
         } else if (ref) {
-          // Assign the DOM element to the object ref
           ref.current = element;
         }
 
-        if (element) {
+        if (element === null) {
+          if (elementRef.current) {
+            elementRef.current.srcObject = null;
+            elementRef.current = null;
+          }
+        } else {
+          if (elementRef.current && elementRef.current !== element) {
+            elementRef.current.srcObject = null;
+          }
+          elementRef.current = element;
           element.srcObject = media;
         }
       },
@@ -50,3 +59,5 @@ export const AudioPlayer = forwardRef<HTMLAudioElement, AudioPlayerProps>(
     return <audio ref={setRef} {...rest} />;
   },
 );
+
+AudioPlayer.displayName = "AudioPlayer";

--- a/packages/react-user-media/src/components/VideoPlayer.spec.tsx
+++ b/packages/react-user-media/src/components/VideoPlayer.spec.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { userEvent } from "@vitest/browser/context";
 import { render, screen, act } from "@testing-library/react";
 import { VideoPlayer } from "./VideoPlayer";
+import { getHostRefCallback } from "./media-player-test-utils";
 import { useMedia } from "../";
 
 function UserMediaTestComponent() {
@@ -51,4 +52,20 @@ test("clears srcObject on unmount", () => {
   unmount();
 
   expect(element!.srcObject).toBeNull();
+});
+
+test("clears srcObject on previous element when DOM element is replaced", () => {
+  const stream = new MediaStream();
+  const { container } = render(<VideoPlayer media={stream} />);
+  const previousElement = container.querySelector("video")!;
+  const nextElement = document.createElement("video");
+
+  expect(previousElement.srcObject).toBe(stream);
+
+  act(() => {
+    getHostRefCallback(previousElement)(nextElement);
+  });
+
+  expect(previousElement.srcObject).toBeNull();
+  expect(nextElement.srcObject).toBe(stream);
 });

--- a/packages/react-user-media/src/components/VideoPlayer.spec.tsx
+++ b/packages/react-user-media/src/components/VideoPlayer.spec.tsx
@@ -29,3 +29,26 @@ test("plays back userMedia video", async () => {
 
   expect(player.played.length).toBeGreaterThan(0);
 });
+
+test("clears srcObject on unmount", () => {
+  const stream = new MediaStream();
+  let element: HTMLVideoElement | null = null;
+
+  const { unmount } = render(
+    <VideoPlayer
+      ref={(el) => {
+        if (el) {
+          element = el;
+        }
+      }}
+      media={stream}
+    />,
+  );
+
+  expect(element).not.toBeNull();
+  expect(element!.srcObject).toBe(stream);
+
+  unmount();
+
+  expect(element!.srcObject).toBeNull();
+});

--- a/packages/react-user-media/src/components/VideoPlayer.tsx
+++ b/packages/react-user-media/src/components/VideoPlayer.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   VideoHTMLAttributes,
   useCallback,
+  useRef,
 } from "react";
 
 type VideoElementProps = DetailedHTMLProps<
@@ -14,7 +15,7 @@ type VideoElementProps = DetailedHTMLProps<
  * React props for {@link VideoPlayer}.
  */
 export interface VideoPlayerProps
-  extends Omit<VideoElementProps, keyof Pick<VideoElementProps, "src">> {
+  extends Omit<VideoElementProps, "src" | "srcObject"> {
   /**
    * The {@link MediaProvider} instance to play.
    */
@@ -22,25 +23,33 @@ export interface VideoPlayerProps
 }
 
 /**
- * Component for easier audio playback. Wraps {@link HTMLVideoElement|&lt;video&gt;}.
+ * Component for easier video playback. Wraps {@link HTMLVideoElement|&lt;video&gt;}.
  *
  * See {@link VideoPlayerProps}.
  */
 export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
   function VideoPlayer(props, ref) {
     const { media, ...rest } = props;
+    const elementRef = useRef<HTMLVideoElement | null>(null);
 
     const setRef = useCallback(
-      (element: HTMLVideoElement) => {
+      (element: HTMLVideoElement | null) => {
         if (typeof ref === "function") {
-          // Pass the DOM element to the callback ref
           ref(element);
         } else if (ref) {
-          // Assign the DOM element to the object ref
           ref.current = element;
         }
 
-        if (element) {
+        if (element === null) {
+          if (elementRef.current) {
+            elementRef.current.srcObject = null;
+            elementRef.current = null;
+          }
+        } else {
+          if (elementRef.current && elementRef.current !== element) {
+            elementRef.current.srcObject = null;
+          }
+          elementRef.current = element;
           element.srcObject = media;
         }
       },
@@ -50,3 +59,5 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     return <video ref={setRef} {...rest} />;
   },
 );
+
+VideoPlayer.displayName = "VideoPlayer";

--- a/packages/react-user-media/src/components/media-player-test-utils.ts
+++ b/packages/react-user-media/src/components/media-player-test-utils.ts
@@ -1,0 +1,20 @@
+export function getHostRefCallback<T extends HTMLElement>(
+  element: T,
+): (el: T | null) => void {
+  const fiberKey = Object.keys(element).find((key) =>
+    key.startsWith("__reactFiber"),
+  );
+  if (!fiberKey) {
+    throw new Error("React fiber not found on element");
+  }
+
+  const fiber = (element as unknown as Record<string, unknown>)[fiberKey] as {
+    ref?: (el: T | null) => void;
+  };
+
+  if (typeof fiber.ref !== "function") {
+    throw new Error("Host ref callback not found on React fiber");
+  }
+
+  return fiber.ref;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Player docs/`srcObject` cleanup, plus element-swap coverage from review.

## Changes

- VideoPlayer JSDoc fix; omit `src`/`srcObject`; `displayName`
- Clear `srcObject` on unmount and when the DOM element is replaced
- Tests: unmount cleanup **and** element-swap cleanup for Audio + Video
- CI pin commits (rebase after #12)

## Test plan

- [x] Player component tests
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

