### PR TITLE
fix(media-devices): clear loading and add idle state

### DIFF
--- a/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { userEvent } from "@vitest/browser/context";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import { useMediaDevices } from "../";
 
 function AllDevicesTestComponent() {
@@ -24,12 +24,237 @@ function AllDevicesTestComponent() {
   );
 }
 
+interface MediaDevicesStatus {
+  isLoading: boolean;
+  isError: boolean;
+  isReady: boolean;
+  error: string | null;
+  deviceCount: number | null;
+}
+
+function StatusDevicesTestComponent() {
+  const { isLoading, isError, isReady, error, devices, request } =
+    useMediaDevices({
+      deviceChangedEvent: false,
+    });
+
+  return (
+    <>
+      <button onClick={() => act(() => request())}>Begin Test</button>
+      <pre data-testid="media-devices-status">
+        {JSON.stringify({
+          isLoading,
+          isError,
+          isReady,
+          error: error?.message ?? null,
+          deviceCount: devices?.length ?? null,
+        } satisfies MediaDevicesStatus)}
+      </pre>
+    </>
+  );
+}
+
+function readStatus() {
+  return JSON.parse(
+    screen.getByTestId("media-devices-status").textContent ?? "{}",
+  ) as MediaDevicesStatus;
+}
+
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  let reject: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return {
+    promise,
+    resolve: resolve!,
+    reject: reject!,
+  };
+}
+
+function createMediaDeviceInfo(): MediaDeviceInfo {
+  return {
+    deviceId: "device-id",
+    groupId: "group-id",
+    kind: "videoinput",
+    label: "Camera",
+    toJSON() {
+      return this;
+    },
+  } as MediaDeviceInfo;
+}
+
+function replaceEnumerateDevices(
+  enumerateDevices: MediaDevices["enumerateDevices"],
+) {
+  const existingDescriptor = Object.getOwnPropertyDescriptor(
+    navigator.mediaDevices,
+    "enumerateDevices",
+  );
+
+  Object.defineProperty(navigator.mediaDevices, "enumerateDevices", {
+    configurable: true,
+    value: enumerateDevices,
+  });
+
+  return function restoreEnumerateDevices() {
+    if (existingDescriptor) {
+      Object.defineProperty(
+        navigator.mediaDevices,
+        "enumerateDevices",
+        existingDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(navigator.mediaDevices, "enumerateDevices");
+    }
+  };
+}
+
+function replaceMediaDevices(mediaDevices: MediaDevices | undefined) {
+  const prototype = Object.getPrototypeOf(navigator);
+  const ownDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "mediaDevices",
+  );
+  const prototypeDescriptor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "mediaDevices",
+  );
+  const target = ownDescriptor ? navigator : prototype;
+  const existingDescriptor = ownDescriptor ?? prototypeDescriptor;
+
+  Object.defineProperty(target, "mediaDevices", {
+    configurable: true,
+    get() {
+      return mediaDevices;
+    },
+  });
+
+  return function restoreMediaDevices() {
+    if (existingDescriptor) {
+      Object.defineProperty(target, "mediaDevices", existingDescriptor);
+    } else {
+      Reflect.deleteProperty(target, "mediaDevices");
+    }
+  };
+}
+
+test("surfaces an error when mediaDevices is unavailable", async () => {
+  const restoreMediaDevices = replaceMediaDevices(undefined);
+
+  try {
+    render(<StatusDevicesTestComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await waitFor(() => {
+      expect(readStatus()).toEqual({
+        isLoading: false,
+        isError: true,
+        isReady: false,
+        error: "enumerateDevices is not available. Are you in a secure context?",
+        deviceCount: null,
+      });
+    });
+  } finally {
+    restoreMediaDevices();
+  }
+});
+
 test("enumerates media devices", async () => {
-  render(<AllDevicesTestComponent />);
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
 
-  await userEvent.click(await screen.findByText("Begin Test"));
+  try {
+    render(<AllDevicesTestComponent />);
 
-  const list = await screen.findByTestId<HTMLUListElement>("device-list");
+    await userEvent.click(await screen.findByText("Begin Test"));
 
-  expect(list.children.length).toBeGreaterThan(0);
+    await act(async () => {
+      devicesRequest.resolve([createMediaDeviceInfo()]);
+      await devicesRequest.promise;
+    });
+
+    const list = await screen.findByTestId<HTMLUListElement>("device-list");
+
+    expect(list.children.length).toBe(1);
+    expect(list).toHaveTextContent("Camera videoinput");
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("starts idle before requesting media devices", () => {
+  render(<StatusDevicesTestComponent />);
+
+  expect(readStatus()).toEqual({
+    isLoading: false,
+    isError: false,
+    isReady: false,
+    error: null,
+    deviceCount: null,
+  });
+});
+
+test("clears loading when media devices are ready", async () => {
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
+
+  try {
+    render(<StatusDevicesTestComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      devicesRequest.resolve([createMediaDeviceInfo()]);
+      await devicesRequest.promise;
+    });
+
+    expect(readStatus()).toEqual({
+      isLoading: false,
+      isError: false,
+      isReady: true,
+      error: null,
+      deviceCount: expect.any(Number),
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("clears loading when requesting media devices fails", async () => {
+  const requestError = new Error("enumerate failed");
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
+
+  try {
+    render(<StatusDevicesTestComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      devicesRequest.reject(requestError);
+      await devicesRequest.promise.catch(() => undefined);
+    });
+
+    expect(readStatus()).toEqual({
+      isLoading: false,
+      isError: true,
+      isReady: false,
+      error: requestError.message,
+      deviceCount: null,
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
 });

--- a/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
@@ -143,6 +143,40 @@ function replaceMediaDevices(mediaDevices: MediaDevices | undefined) {
   };
 }
 
+function DefaultOptionsDevicesTestComponent() {
+  const { isLoading, isError, isReady, error, devices } = useMediaDevices();
+
+  return (
+    <pre data-testid="media-devices-status">
+      {JSON.stringify({
+        isLoading,
+        isError,
+        isReady,
+        error: error?.message ?? null,
+        deviceCount: devices?.length ?? null,
+      } satisfies MediaDevicesStatus)}
+    </pre>
+  );
+}
+
+test("does not throw when mediaDevices is unavailable with default options", () => {
+  const restoreMediaDevices = replaceMediaDevices(undefined);
+
+  try {
+    expect(() => render(<DefaultOptionsDevicesTestComponent />)).not.toThrow();
+
+    expect(readStatus()).toEqual({
+      isLoading: false,
+      isError: false,
+      isReady: false,
+      error: null,
+      deviceCount: null,
+    });
+  } finally {
+    restoreMediaDevices();
+  }
+});
+
 test("surfaces an error when mediaDevices is unavailable", async () => {
   const restoreMediaDevices = replaceMediaDevices(undefined);
 

--- a/packages/react-user-media/src/hooks/use-media-devices.ts
+++ b/packages/react-user-media/src/hooks/use-media-devices.ts
@@ -16,6 +16,17 @@ interface MediaDeviceStateBase {
 }
 
 /**
+ * The idle state of the {@link useMediaDevices} response.
+ */
+interface MediaDeviceIdleState extends MediaDeviceStateBase {
+  isLoading: false;
+  isError: false;
+  isReady: false;
+  error: null;
+  devices: undefined;
+}
+
+/**
  * The error state of the {@link useMediaDevices} response.
  */
 interface MediaDeviceErrorState extends MediaDeviceStateBase {
@@ -52,6 +63,7 @@ interface MediaDeviceReadyState extends MediaDeviceStateBase {
  * The state of the {@link useMediaDevices} response.
  */
 export type MediaDeviceState =
+  | MediaDeviceIdleState
   | MediaDeviceErrorState
   | MediaDeviceLoadingState
   | MediaDeviceReadyState;
@@ -112,8 +124,12 @@ export function useMediaDevices(
 
   const request = useCallback(
     function requestMediaDevices() {
-      if (!navigator.mediaDevices.enumerateDevices) {
+      const mediaDevices = navigator.mediaDevices;
+
+      if (!mediaDevices?.enumerateDevices) {
         // see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+        setIsLoading(false);
+        setDevices(undefined);
         return setError(
           new Error(
             `enumerateDevices is not available. Are you in a secure context?`,
@@ -125,14 +141,16 @@ export function useMediaDevices(
       setDevices(undefined);
       setError(null);
 
-      navigator.mediaDevices.enumerateDevices().then(
+      mediaDevices.enumerateDevices().then(
         function onRequestSuccess(devices) {
           setDevices(devices.filter(filter));
           setError(null);
+          setIsLoading(false);
         },
         function onRequestError(error) {
           setError(error);
           setDevices(undefined);
+          setIsLoading(false);
         },
       );
     },
@@ -141,20 +159,19 @@ export function useMediaDevices(
 
   useEffect(
     function requestMediaDevicesEvent() {
-      if (deviceChangedEvent) {
+      const mediaDevices = navigator.mediaDevices;
+
+      if (deviceChangedEvent && mediaDevices?.addEventListener) {
         // note: This only fires in secure contexts
         // see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/devicechange_event
         const onDeviceChange = () => {
           request();
         };
 
-        navigator.mediaDevices.addEventListener("devicechange", onDeviceChange);
+        mediaDevices.addEventListener("devicechange", onDeviceChange);
 
         return function teardown() {
-          navigator.mediaDevices.removeEventListener(
-            "devicechange",
-            onDeviceChange,
-          );
+          mediaDevices.removeEventListener("devicechange", onDeviceChange);
         };
       }
     },

--- a/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { userEvent } from "@vitest/browser/context";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import { useMedia, useMediaRecorder, VideoPlayer } from "../";
 
 function UserMediaTestComponent() {
@@ -50,7 +50,12 @@ test("records userMedia video", async () => {
 
   await userEvent.click(await screen.findByText("Start Recording"));
 
-  await new Promise((resolve) => setTimeout(resolve, 200));
+  await waitFor(
+    () => {
+      expect(player.played.length).toBeGreaterThan(0);
+    },
+    { timeout: 5000 },
+  );
 
   await userEvent.click(await screen.findByText("Stop Recording"));
 
@@ -58,6 +63,5 @@ test("records userMedia video", async () => {
     "media-recorded-length",
   );
 
-  expect(player.played.length).toBeGreaterThan(0);
   expect(Number(recordedLengthEl.innerText).valueOf()).toBeGreaterThan(0);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `useMediaDevices` loading/idle/`mediaDevices` guards, plus review follow-ups.

## Changes

- Clear `isLoading` on enumerate success and error
- Add `MediaDeviceIdleState` to the public union
- Optional-chain `navigator.mediaDevices` (request + `devicechange` subscription)
- Tests: idle, loading cleared, missing `mediaDevices` (including **default** `deviceChangedEvent` path)
- CI: pin pnpm via `packageManager` + Node 22
- Test: recorder playback `waitFor` flake harden

## Test plan

- [x] Package tests
- [ ] CI green after follow-up push
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

