### PR TITLE
fix(tracks): correct track cache and stabilize filtered snapshots

### DIFF
--- a/packages/react-user-media/src/hooks/use-media-ext.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-ext.spec.tsx
@@ -91,6 +91,27 @@ test("returns a stable empty array when media becomes undefined", async () => {
   expect(result.current).toBe(emptyTracks);
 });
 
+test("does not poison empty track snapshots when a caller mutates one", async () => {
+  const track = await createTrack("audio");
+  const { result } = renderHook(() => useMediaTracks(undefined));
+  const emptyTracks = result.current;
+
+  expect(emptyTracks).toEqual([]);
+
+  let mutationError: unknown;
+  try {
+    emptyTracks.push(track);
+  } catch (error) {
+    mutationError = error;
+  }
+
+  const { result: nextResult } = renderHook(() => useMediaTracks(undefined));
+
+  expect(nextResult.current).toEqual([]);
+  expect(Object.isFrozen(emptyTracks)).toBe(true);
+  expect(mutationError).toBeInstanceOf(TypeError);
+});
+
 test("keeps audio track references stable when only video tracks change", async () => {
   const audioTrack = await createTrack("audio");
   const videoTrack = await createTrack("video");

--- a/packages/react-user-media/src/hooks/use-media-ext.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-ext.spec.tsx
@@ -1,0 +1,130 @@
+import { renderHook, act } from "@testing-library/react";
+import { useMediaAudioTracks, useMediaTracks, useMediaVideoTracks } from "../";
+
+const createdTracks: MediaStreamTrack[] = [];
+
+afterEach(() => {
+  createdTracks.splice(0).forEach((track) => track.stop());
+});
+
+async function createTrack(kind: MediaStreamTrack["kind"]) {
+  const constraints: MediaStreamConstraints =
+    kind === "audio" ? { audio: true } : { video: true };
+  const media = await navigator.mediaDevices.getUserMedia(constraints);
+  const track = media.getTracks().find((candidate) => candidate.kind === kind);
+
+  if (!track) {
+    throw new Error(`Unable to create ${kind} track`);
+  }
+
+  createdTracks.push(...media.getTracks());
+
+  return track;
+}
+
+function dispatchTrackEvent(
+  media: MediaStream,
+  eventName: "addtrack" | "removetrack",
+) {
+  media.dispatchEvent(new Event(eventName));
+}
+
+test("updates media tracks when a track is removed", async () => {
+  const audioTrack = await createTrack("audio");
+  const videoTrack = await createTrack("video");
+  const media = new MediaStream([audioTrack, videoTrack]);
+  const { result } = renderHook(() => useMediaTracks(media));
+
+  expect(result.current).toHaveLength(2);
+  expect(result.current[0]).toBe(audioTrack);
+  expect(result.current[1]).toBe(videoTrack);
+
+  act(() => {
+    media.removeTrack(audioTrack);
+    dispatchTrackEvent(media, "removetrack");
+  });
+
+  expect(result.current).toHaveLength(1);
+  expect(result.current[0]).toBe(videoTrack);
+});
+
+test("updates media tracks when a track is replaced at the same count", async () => {
+  const originalTrack = await createTrack("audio");
+  const replacementTrack = await createTrack("audio");
+  const media = new MediaStream([originalTrack]);
+  const { result } = renderHook(() => useMediaTracks(media));
+
+  expect(result.current).toHaveLength(1);
+  expect(result.current[0]).toBe(originalTrack);
+
+  act(() => {
+    media.removeTrack(originalTrack);
+    media.addTrack(replacementTrack);
+    dispatchTrackEvent(media, "removetrack");
+    dispatchTrackEvent(media, "addtrack");
+  });
+
+  expect(result.current).toHaveLength(1);
+  expect(result.current[0]).toBe(replacementTrack);
+});
+
+test("returns a stable empty array when media becomes undefined", async () => {
+  const track = await createTrack("audio");
+  const media = new MediaStream([track]);
+  const { result, rerender } = renderHook(
+    ({ currentMedia }: { currentMedia: MediaStream | undefined }) =>
+      useMediaTracks(currentMedia),
+    { initialProps: { currentMedia: media } },
+  );
+
+  expect(result.current).toHaveLength(1);
+  expect(result.current[0]).toBe(track);
+
+  rerender({ currentMedia: undefined });
+
+  expect(result.current).toEqual([]);
+
+  const emptyTracks = result.current;
+
+  rerender({ currentMedia: undefined });
+
+  expect(result.current).toBe(emptyTracks);
+});
+
+test("keeps audio track references stable when only video tracks change", async () => {
+  const audioTrack = await createTrack("audio");
+  const videoTrack = await createTrack("video");
+  const media = new MediaStream([audioTrack]);
+  const { result } = renderHook(() => useMediaAudioTracks(media));
+
+  expect(result.current).toHaveLength(1);
+  expect(result.current[0]).toBe(audioTrack);
+
+  const audioTracks = result.current;
+
+  act(() => {
+    media.addTrack(videoTrack);
+    dispatchTrackEvent(media, "addtrack");
+  });
+
+  expect(result.current).toBe(audioTracks);
+});
+
+test("keeps video track references stable when only audio tracks change", async () => {
+  const videoTrack = await createTrack("video");
+  const audioTrack = await createTrack("audio");
+  const media = new MediaStream([videoTrack]);
+  const { result } = renderHook(() => useMediaVideoTracks(media));
+
+  expect(result.current).toHaveLength(1);
+  expect(result.current[0]).toBe(videoTrack);
+
+  const videoTracks = result.current;
+
+  act(() => {
+    media.addTrack(audioTrack);
+    dispatchTrackEvent(media, "addtrack");
+  });
+
+  expect(result.current).toBe(videoTracks);
+});

--- a/packages/react-user-media/src/hooks/use-media-ext.ts
+++ b/packages/react-user-media/src/hooks/use-media-ext.ts
@@ -1,10 +1,10 @@
 import { useSyncExternalStore, useCallback, useRef } from "react";
 
-const EMPTY_TRACKS: MediaStreamTrack[] = [];
+const EMPTY_TRACKS = Object.freeze([]) as MediaStreamTrack[];
 
 function hasSameTrackIds(
-  latestTracks: MediaStreamTrack[],
-  cachedTracks: MediaStreamTrack[],
+  latestTracks: readonly MediaStreamTrack[],
+  cachedTracks: readonly MediaStreamTrack[],
 ) {
   if (latestTracks.length !== cachedTracks.length) {
     return false;
@@ -27,15 +27,43 @@ function useMediaTracksByKind(
   media: MediaStream | undefined,
   kind: MediaStreamTrack["kind"],
 ) {
-  const tracks = useMediaTracks(media);
   const trackCache = useRef<MediaStreamTrack[]>(EMPTY_TRACKS);
-  const latestTracks = tracks.filter((track) => track.kind === kind);
 
-  if (!hasSameTrackIds(latestTracks, trackCache.current)) {
-    trackCache.current = latestTracks.length > 0 ? latestTracks : EMPTY_TRACKS;
-  }
+  return useSyncExternalStore(
+    useCallback(
+      function subscribe(callback) {
+        media?.addEventListener("addtrack", callback);
+        media?.addEventListener("removetrack", callback);
 
-  return trackCache.current;
+        return function unsubscribe() {
+          media?.removeEventListener("addtrack", callback);
+          media?.removeEventListener("removetrack", callback);
+        };
+      },
+      [media],
+    ),
+    useCallback(
+      function getSnapshot() {
+        if (!media) {
+          trackCache.current = EMPTY_TRACKS;
+
+          return trackCache.current;
+        }
+
+        const latestTracks = media
+          .getTracks()
+          .filter((track) => track.kind === kind);
+
+        if (!hasSameTrackIds(latestTracks, trackCache.current)) {
+          trackCache.current =
+            latestTracks.length > 0 ? latestTracks : EMPTY_TRACKS;
+        }
+
+        return trackCache.current;
+      },
+      [kind, media],
+    ),
+  );
 }
 
 /**

--- a/packages/react-user-media/src/hooks/use-media-ext.ts
+++ b/packages/react-user-media/src/hooks/use-media-ext.ts
@@ -1,5 +1,43 @@
 import { useSyncExternalStore, useCallback, useRef } from "react";
 
+const EMPTY_TRACKS: MediaStreamTrack[] = [];
+
+function hasSameTrackIds(
+  latestTracks: MediaStreamTrack[],
+  cachedTracks: MediaStreamTrack[],
+) {
+  if (latestTracks.length !== cachedTracks.length) {
+    return false;
+  }
+
+  const latestTrackIds = new Set(latestTracks.map((track) => track.id));
+  const cachedTrackIds = new Set(cachedTracks.map((track) => track.id));
+
+  if (latestTrackIds.size !== cachedTrackIds.size) {
+    return false;
+  }
+
+  return (
+    latestTracks.every((track) => cachedTrackIds.has(track.id)) &&
+    cachedTracks.every((track) => latestTrackIds.has(track.id))
+  );
+}
+
+function useMediaTracksByKind(
+  media: MediaStream | undefined,
+  kind: MediaStreamTrack["kind"],
+) {
+  const tracks = useMediaTracks(media);
+  const trackCache = useRef<MediaStreamTrack[]>(EMPTY_TRACKS);
+  const latestTracks = tracks.filter((track) => track.kind === kind);
+
+  if (!hasSameTrackIds(latestTracks, trackCache.current)) {
+    trackCache.current = latestTracks.length > 0 ? latestTracks : EMPTY_TRACKS;
+  }
+
+  return trackCache.current;
+}
+
 /**
  * Hook that observes {@link MediaStream.getTracks} and provides access
  * to the results.
@@ -24,21 +62,19 @@ export function useMediaTracks(media: MediaStream | undefined) {
     ),
     useCallback(
       function getSnapshot() {
-        if (media) {
-          // get tracks _always_ returns a new array
-          // so we can't rely on it's stability
-          const latestTracks = media.getTracks();
+        if (!media) {
+          trackCache.current = EMPTY_TRACKS;
 
-          // if the latest tracks and the cached tracks count are the same
-          if (latestTracks.length !== trackCache.current.length) {
-            const latestTrackIds = latestTracks.map((t) => t.id);
-            const cachedTrackIds = trackCache.current.map((t) => t.id);
+          return trackCache.current;
+        }
 
-            // and cachedTrackIds contains all the latestTrackIds
-            if (!latestTrackIds.every((id) => cachedTrackIds.includes(id))) {
-              trackCache.current = latestTracks;
-            }
-          }
+        // get tracks _always_ returns a new array
+        // so we can't rely on its stability
+        const latestTracks = media.getTracks();
+
+        if (!hasSameTrackIds(latestTracks, trackCache.current)) {
+          trackCache.current =
+            latestTracks.length > 0 ? latestTracks : EMPTY_TRACKS;
         }
 
         // in the event of a cache update, this is technically the _last_
@@ -59,7 +95,7 @@ export function useMediaTracks(media: MediaStream | undefined) {
  * @returns an array of audio {@link MediaStreamTrack}s.
  */
 export function useMediaAudioTracks(media: MediaStream | undefined) {
-  return useMediaTracks(media).filter((t) => t.kind === "audio");
+  return useMediaTracksByKind(media, "audio");
 }
 
 /**
@@ -70,7 +106,7 @@ export function useMediaAudioTracks(media: MediaStream | undefined) {
  * @returns an array of video {@link MediaStreamTrack}s.
  */
 export function useMediaVideoTracks(media: MediaStream | undefined) {
-  return useMediaTracks(media).filter((t) => t.kind === "video");
+  return useMediaTracksByKind(media, "video");
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects `useMediaTracks` caching and filtered snapshot stability, including review follow-ups.

## Changes

- Symmetric track-id cache updates (remove / same-length replace)
- Stable empty snapshot when `media` is undefined
- Filtered audio/video hooks use their own `useSyncExternalStore` snapshots
- **`EMPTY_TRACKS` is `Object.freeze`d** so callers cannot poison the singleton
- Regression test for empty-snapshot mutation poisoning
- CI pin commits (rebase after #12)

## Test plan

- [x] Package tests (incl. poison regression)
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

