### PR TITLE
fix(use-media): stop leaks, races, and add stop()/idle

### DIFF
--- a/packages/react-user-media/src/close-media.ts
+++ b/packages/react-user-media/src/close-media.ts
@@ -1,0 +1,5 @@
+export function closeMedia(media: MediaStream | undefined) {
+  media?.getTracks().forEach(function closeMediaTrack(track) {
+    track.stop();
+  });
+}

--- a/packages/react-user-media/src/hooks/use-media.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media.spec.tsx
@@ -23,8 +23,20 @@ function createFakeMediaStream(id: string) {
   return { media, track };
 }
 
+function createDeferredMediaStream() {
+  let resolve!: (media: MediaStream) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<MediaStream>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function UserMediaTestComponent() {
-  const { isError, isLoading, isReady, media, request, stop } = useMedia("user");
+  const { error, isError, isLoading, isReady, media, request, stop } =
+    useMedia("user");
 
   return (
     <>
@@ -34,6 +46,21 @@ function UserMediaTestComponent() {
         {isReady ? "ready" : isLoading ? "loading" : isError ? "error" : "idle"}
       </p>
       <p data-testid="media-id">{media?.id ?? "none"}</p>
+      <p data-testid="error-message">{error?.message ?? "none"}</p>
+    </>
+  );
+}
+
+function DisplayMediaTestComponent() {
+  const { isError, isLoading, isReady, media, request } = useMedia("display");
+
+  return (
+    <>
+      <button onClick={() => request({ video: true })}>Request Display</button>
+      <p data-testid="display-state">
+        {isReady ? "ready" : isLoading ? "loading" : isError ? "error" : "idle"}
+      </p>
+      <p data-testid="display-media-id">{media?.id ?? "none"}</p>
     </>
   );
 }
@@ -98,4 +125,137 @@ test("stop clears ready user media", async () => {
     expect(screen.getByTestId("state")).toHaveTextContent("idle");
     expect(screen.getByTestId("media-id")).toHaveTextContent("none");
   });
+});
+
+test("unmount cleanup stops ready user media tracks", async () => {
+  const stream = createFakeMediaStream("stream");
+  vi.spyOn(navigator.mediaDevices, "getUserMedia").mockResolvedValueOnce(
+    stream.media,
+  );
+
+  const { unmount } = render(<UserMediaTestComponent />);
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("ready");
+  });
+
+  unmount();
+
+  expect(stream.track.stop).toHaveBeenCalledTimes(1);
+  expect(stream.track.readyState).toBe("ended");
+});
+
+test("stale user media promises after stop and re-request do not replace newer media", async () => {
+  const stale = createFakeMediaStream("stale");
+  const fresh = createFakeMediaStream("fresh");
+  const staleRequest = createDeferredMediaStream();
+  const freshRequest = createDeferredMediaStream();
+
+  vi.spyOn(navigator.mediaDevices, "getUserMedia")
+    .mockReturnValueOnce(staleRequest.promise)
+    .mockReturnValueOnce(freshRequest.promise);
+
+  render(<UserMediaTestComponent />);
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  act(() => {
+    screen.getByText("Stop").click();
+  });
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  await act(async () => {
+    freshRequest.resolve(fresh.media);
+    await freshRequest.promise;
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("media-id")).toHaveTextContent("fresh");
+  });
+
+  await act(async () => {
+    staleRequest.resolve(stale.media);
+    await staleRequest.promise;
+  });
+
+  await waitFor(() => {
+    expect(stale.track.stop).toHaveBeenCalledTimes(1);
+    expect(stale.track.readyState).toBe("ended");
+    expect(screen.getByTestId("state")).toHaveTextContent("ready");
+    expect(screen.getByTestId("media-id")).toHaveTextContent("fresh");
+  });
+
+  expect(fresh.track.stop).not.toHaveBeenCalled();
+});
+
+test("missing mediaDevices reports an error state without throwing", async () => {
+  const mediaDevices = navigator.mediaDevices;
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: undefined,
+  });
+
+  try {
+    render(<UserMediaTestComponent />);
+
+    expect(() => {
+      act(() => {
+        screen.getByText("Request").click();
+      });
+    }).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("state")).toHaveTextContent("error");
+      expect(screen.getByTestId("media-id")).toHaveTextContent("none");
+      expect(screen.getByTestId("error-message")).toHaveTextContent(
+        "getUserMedia is not available",
+      );
+    });
+  } finally {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: mediaDevices,
+    });
+  }
+});
+
+test("requests display media", async () => {
+  const stream = createFakeMediaStream("display");
+  const getDisplayMedia = vi.fn().mockResolvedValueOnce(stream.media);
+  const originalGetDisplayMedia = navigator.mediaDevices.getDisplayMedia;
+
+  Object.defineProperty(navigator.mediaDevices, "getDisplayMedia", {
+    configurable: true,
+    value: getDisplayMedia,
+  });
+
+  try {
+    render(<DisplayMediaTestComponent />);
+
+    act(() => {
+      screen.getByText("Request Display").click();
+    });
+
+    await waitFor(() => {
+      expect(getDisplayMedia).toHaveBeenCalledWith({ video: true });
+      expect(screen.getByTestId("display-state")).toHaveTextContent("ready");
+      expect(screen.getByTestId("display-media-id")).toHaveTextContent(
+        "display",
+      );
+    });
+  } finally {
+    Object.defineProperty(navigator.mediaDevices, "getDisplayMedia", {
+      configurable: true,
+      value: originalGetDisplayMedia,
+    });
+  }
 });

--- a/packages/react-user-media/src/hooks/use-media.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media.spec.tsx
@@ -1,0 +1,101 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor, cleanup, act } from "@testing-library/react";
+import { vi } from "vitest";
+import { useMedia } from "../";
+
+interface FakeMediaStream extends MediaStream {
+  id: string;
+}
+
+function createFakeMediaStream(id: string) {
+  const track = {
+    readyState: "live" as MediaStreamTrackState,
+    stop: vi.fn(function stopTrack() {
+      track.readyState = "ended";
+    }),
+  };
+
+  const media = {
+    id,
+    getTracks: () => [track],
+  } as unknown as FakeMediaStream;
+
+  return { media, track };
+}
+
+function UserMediaTestComponent() {
+  const { isError, isLoading, isReady, media, request, stop } = useMedia("user");
+
+  return (
+    <>
+      <button onClick={() => request({ video: true })}>Request</button>
+      <button onClick={() => stop()}>Stop</button>
+      <p data-testid="state">
+        {isReady ? "ready" : isLoading ? "loading" : isError ? "error" : "idle"}
+      </p>
+      <p data-testid="media-id">{media?.id ?? "none"}</p>
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+test("stops the previous user media stream when re-requesting", async () => {
+  const first = createFakeMediaStream("first");
+  const second = createFakeMediaStream("second");
+  vi.spyOn(navigator.mediaDevices, "getUserMedia")
+    .mockResolvedValueOnce(first.media)
+    .mockResolvedValueOnce(second.media);
+
+  render(<UserMediaTestComponent />);
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("media-id")).toHaveTextContent("first");
+  });
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  expect(first.track.stop).toHaveBeenCalledTimes(1);
+  expect(first.track.readyState).toBe("ended");
+
+  await waitFor(() => {
+    expect(screen.getByTestId("media-id")).toHaveTextContent("second");
+  });
+});
+
+test("stop clears ready user media", async () => {
+  const stream = createFakeMediaStream("stream");
+  vi.spyOn(navigator.mediaDevices, "getUserMedia").mockResolvedValueOnce(
+    stream.media,
+  );
+
+  render(<UserMediaTestComponent />);
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("ready");
+  });
+
+  act(() => {
+    screen.getByText("Stop").click();
+  });
+
+  expect(stream.track.stop).toHaveBeenCalledTimes(1);
+  expect(stream.track.readyState).toBe("ended");
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("idle");
+    expect(screen.getByTestId("media-id")).toHaveTextContent("none");
+  });
+});

--- a/packages/react-user-media/src/hooks/use-media.ts
+++ b/packages/react-user-media/src/hooks/use-media.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { closeMedia } from "../close-media";
 import { ShallowShapeOf } from "../types";
 
 // base types for MediaStateBase
@@ -161,12 +162,6 @@ export type DisplayMediaState =
   | DisplayMediaErrorState
   | DisplayMediaLoadingState
   | DisplayMediaReadyState;
-
-function closeMedia(media: MediaStream | undefined) {
-  media?.getTracks().forEach(function closeMediaTrack(track) {
-    track.stop();
-  });
-}
 
 function toError(error: unknown) {
   return error instanceof Error ? error : new Error(String(error));

--- a/packages/react-user-media/src/hooks/use-media.ts
+++ b/packages/react-user-media/src/hooks/use-media.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ShallowShapeOf } from "../types";
 
 // base types for MediaStateBase
@@ -48,6 +48,22 @@ interface MediaStateBase<T> {
    * Requests new {@link media} on behalf of the user.
    */
   request(options?: T): void;
+
+  /**
+   * Stops the current {@link media} and returns to idle.
+   */
+  stop(): void;
+}
+
+/**
+ * The idle state of {@link useMedia} response.
+ */
+interface UserMediaIdleState extends MediaStateBase<UserMediaBaseType> {
+  isLoading: false;
+  isError: false;
+  isReady: false;
+  error: null;
+  media: undefined;
 }
 
 /**
@@ -87,9 +103,21 @@ interface UserMediaReadyState extends MediaStateBase<UserMediaBaseType> {
  * The state of {@link useMedia} response.
  */
 export type UserMediaState =
+  | UserMediaIdleState
   | UserMediaErrorState
   | UserMediaLoadingState
   | UserMediaReadyState;
+
+/**
+ * The displayMedia idle state of {@link useMedia} response.
+ */
+interface DisplayMediaIdleState extends MediaStateBase<DisplayMediaBaseType> {
+  isLoading: false;
+  isError: false;
+  isReady: false;
+  error: null;
+  media: undefined;
+}
 
 /**
  * The displayMedia error state of {@link useMedia} response.
@@ -129,9 +157,20 @@ interface DisplayMediaReadyState extends MediaStateBase<DisplayMediaBaseType> {
  * The displayMedia state of {@link useMedia} response.
  */
 export type DisplayMediaState =
+  | DisplayMediaIdleState
   | DisplayMediaErrorState
   | DisplayMediaLoadingState
   | DisplayMediaReadyState;
+
+function closeMedia(media: MediaStream | undefined) {
+  media?.getTracks().forEach(function closeMediaTrack(track) {
+    track.stop();
+  });
+}
+
+function toError(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 // utility types to make defining `useMedia` easier.
 
@@ -184,16 +223,35 @@ export function useMedia<
   const [media, setMedia] = useState<MediaStream | undefined>(undefined);
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const mediaRef = useRef<MediaStream | undefined>(undefined);
+  const requestGeneration = useRef(0);
 
   const isError = useMemo(() => error !== null, [error]);
   const isReady = useMemo(() => typeof media !== "undefined", [media]);
+
+  const stop = useCallback(function stopMedia() {
+    requestGeneration.current += 1;
+    closeMedia(mediaRef.current);
+    mediaRef.current = undefined;
+    setMedia(undefined);
+    setError(null);
+    setIsLoading(false);
+  }, []);
 
   const request = useCallback(
     function requestUserMedia(
       ...args: Parameters<inferMediaDef<TType>["requestType"]["request"]>
     ) {
-      if (type === "user" && !navigator.mediaDevices.getUserMedia) {
+      const currentRequestGeneration = requestGeneration.current + 1;
+      requestGeneration.current = currentRequestGeneration;
+
+      closeMedia(mediaRef.current);
+      mediaRef.current = undefined;
+      setMedia(undefined);
+
+      if (type === "user" && !navigator.mediaDevices?.getUserMedia) {
         // see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
+        setIsLoading(false);
         return setError(
           new Error(
             `getUserMedia is not available. Are you using a modern browser?`,
@@ -201,8 +259,9 @@ export function useMedia<
         );
       }
 
-      if (type === "display" && !navigator.mediaDevices.getDisplayMedia) {
+      if (type === "display" && !navigator.mediaDevices?.getDisplayMedia) {
         // see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
+        setIsLoading(false);
         return setError(
           new Error(
             `getDisplayMedia is not available. Are you in a secure context?`,
@@ -220,16 +279,28 @@ export function useMedia<
             .getUserMedia(...args)
             .then(
               function onRequestSuccess(userMedia) {
+                if (requestGeneration.current !== currentRequestGeneration) {
+                  closeMedia(userMedia);
+                  return;
+                }
+
+                mediaRef.current = userMedia;
                 setMedia(userMedia);
                 setError(null);
               },
               function onRequestError(error) {
-                setError(error);
+                if (requestGeneration.current !== currentRequestGeneration) {
+                  return;
+                }
+
+                setError(toError(error));
                 setMedia(undefined);
               },
             )
             .then(function finalizeRequest() {
-              setIsLoading(false);
+              if (requestGeneration.current === currentRequestGeneration) {
+                setIsLoading(false);
+              }
             });
           break;
         case "display":
@@ -237,16 +308,28 @@ export function useMedia<
             .getDisplayMedia(...args)
             .then(
               function onRequestSuccess(userMedia) {
+                if (requestGeneration.current !== currentRequestGeneration) {
+                  closeMedia(userMedia);
+                  return;
+                }
+
+                mediaRef.current = userMedia;
                 setMedia(userMedia);
                 setError(null);
               },
               function onRequestError(error) {
-                setError(error);
+                if (requestGeneration.current !== currentRequestGeneration) {
+                  return;
+                }
+
+                setError(toError(error));
                 setMedia(undefined);
               },
             )
             .then(function finalizeRequest() {
-              setIsLoading(false);
+              if (requestGeneration.current === currentRequestGeneration) {
+                setIsLoading(false);
+              }
             });
           break;
         default:
@@ -256,6 +339,14 @@ export function useMedia<
     [type],
   );
 
+  useEffect(function stopMediaOnUnmount() {
+    return function teardownMedia() {
+      requestGeneration.current += 1;
+      closeMedia(mediaRef.current);
+      mediaRef.current = undefined;
+    };
+  }, []);
+
   const state = {
     isError,
     isLoading,
@@ -263,6 +354,7 @@ export function useMedia<
     error,
     media,
     request,
+    stop,
   } satisfies ShallowShapeOf<UserMediaState | DisplayMediaState>;
 
   // we cast, as it isn't worth the runtime cost to check that this

--- a/packages/react-user-media/src/index.ts
+++ b/packages/react-user-media/src/index.ts
@@ -1,12 +1,7 @@
 export * from "./hooks";
 export * from "./components";
+export * from "./close-media";
 
 export function getSupportedConstraints() {
   return navigator.mediaDevices?.getSupportedConstraints?.() ?? {};
-}
-
-export function closeMedia(media: MediaStream) {
-  media.getTracks().forEach(function closeMediaTrack(track) {
-    track.stop();
-  });
 }

--- a/packages/react-user-media/src/index.ts
+++ b/packages/react-user-media/src/index.ts
@@ -2,7 +2,7 @@ export * from "./hooks";
 export * from "./components";
 
 export function getSupportedConstraints() {
-  return navigator.mediaDevices.getSupportedConstraints();
+  return navigator.mediaDevices?.getSupportedConstraints?.() ?? {};
 }
 
 export function closeMedia(media: MediaStream) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens `useMedia` lifecycle and addresses review follow-ups.

## Changes

- Stop previous tracks on re-request; unmount cleanup; request generation for stale promises
- Idle union members; `stop()` API; `mediaDevices` / `getSupportedConstraints` guards
- **Shared `closeMedia` in `src/close-media.ts`** (hook + public export, no circular import)
- Tests: re-request, `stop()`, unmount cleanup, stale promise, missing `mediaDevices`, display smoke
- CI pin commits (rebase after #12)

## Test plan

- [x] Package tests + build
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

