### PR TITLE
fix(ci): pin pnpm 10 (Node 20/22 compatible installs)

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: latest
+          version: 10
           run_install: true
       - run: pnpm exec playwright install
       - run: pnpm run lint 
@@ -34,11 +34,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: latest
+          version: 10
           run_install: true
       # TODO(bengreenier): Use an artifact instead
       - run: pnpm run build

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: 22
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 10
           run_install: true
       - run: pnpm exec playwright install
       - run: pnpm run lint 
@@ -38,7 +37,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 10
           run_install: true
       # TODO(bengreenier): Use an artifact instead
       - run: pnpm run build

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: latest
+          version: 10
           run_install: true
 
       - run: pnpm run doc

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -16,7 +16,6 @@ jobs:
           node-version: 22
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 10
           run_install: true
 
       - run: pnpm run doc

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@react-user-media/monorepo",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "pnpm@10.15.1",
   "scripts": {
     "build": "pnpm -r run --if-present build",
     "dev": "pnpm -r run --if-present dev",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI failed during install because `pnpm/action-setup` used `version: latest`, which resolved to **pnpm 11**. pnpm 11 requires **Node ≥ 22.13** and imports `node:sqlite`, which is missing on older Node runners (`ERR_UNKNOWN_BUILTIN_MODULE`).

## Fix

- Add root `packageManager: pnpm@10.15.1` (single source of truth for pnpm/action-setup)
- Remove `version: latest` from workflows so action-setup does not pull pnpm 11
- Bump Actions Node to **22** LTS in `ci_cd.yml` and `github_pages.yml`

## Test plan

- [ ] `CI/CD / build` green on this PR
- [x] Same commits applied to open feature fix PRs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

