### PR TITLE
fix: harden remaining lifecycle races and expand test coverage

### DIFF
--- a/packages/react-user-media/src/close-media.spec.ts
+++ b/packages/react-user-media/src/close-media.spec.ts
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom";
+import { closeMedia, getSupportedConstraints } from "../";
+
+test("closeMedia stops every track on the stream", () => {
+  const stopA = vi.fn();
+  const stopB = vi.fn();
+  const media = {
+    getTracks: () => [{ stop: stopA }, { stop: stopB }],
+  } as unknown as MediaStream;
+
+  closeMedia(media);
+
+  expect(stopA).toHaveBeenCalledTimes(1);
+  expect(stopB).toHaveBeenCalledTimes(1);
+});
+
+test("closeMedia accepts undefined without throwing", () => {
+  expect(() => closeMedia(undefined)).not.toThrow();
+});
+
+test("getSupportedConstraints returns an object when mediaDevices is missing", () => {
+  const prototype = Object.getPrototypeOf(navigator);
+  const ownDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "mediaDevices",
+  );
+  const prototypeDescriptor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "mediaDevices",
+  );
+  const target = ownDescriptor ? navigator : prototype;
+  const existingDescriptor = ownDescriptor ?? prototypeDescriptor;
+
+  Object.defineProperty(target, "mediaDevices", {
+    configurable: true,
+    get() {
+      return undefined;
+    },
+  });
+
+  try {
+    expect(getSupportedConstraints()).toEqual({});
+  } finally {
+    if (existingDescriptor) {
+      Object.defineProperty(target, "mediaDevices", existingDescriptor);
+    } else {
+      Reflect.deleteProperty(target, "mediaDevices");
+    }
+  }
+});
+
+test("getSupportedConstraints returns an object when navigator is unavailable", () => {
+  const existingNavigator = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "navigator",
+  );
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: undefined,
+  });
+
+  try {
+    expect(getSupportedConstraints()).toEqual({});
+  } finally {
+    if (existingNavigator) {
+      Object.defineProperty(globalThis, "navigator", existingNavigator);
+    } else {
+      Reflect.deleteProperty(globalThis, "navigator");
+    }
+  }
+});

--- a/packages/react-user-media/src/components/AudioPlayer.spec.tsx
+++ b/packages/react-user-media/src/components/AudioPlayer.spec.tsx
@@ -69,3 +69,16 @@ test("clears srcObject on previous element when DOM element is replaced", () => 
   expect(previousElement.srcObject).toBeNull();
   expect(nextElement.srcObject).toBe(stream);
 });
+
+test("updates srcObject when the media prop changes", () => {
+  const first = new MediaStream();
+  const second = new MediaStream();
+  const { container, rerender } = render(<AudioPlayer media={first} />);
+  const element = container.querySelector("audio")!;
+
+  expect(element.srcObject).toBe(first);
+
+  rerender(<AudioPlayer media={second} />);
+
+  expect(element.srcObject).toBe(second);
+});

--- a/packages/react-user-media/src/components/VideoPlayer.spec.tsx
+++ b/packages/react-user-media/src/components/VideoPlayer.spec.tsx
@@ -69,3 +69,16 @@ test("clears srcObject on previous element when DOM element is replaced", () => 
   expect(previousElement.srcObject).toBeNull();
   expect(nextElement.srcObject).toBe(stream);
 });
+
+test("updates srcObject when the media prop changes", () => {
+  const first = new MediaStream();
+  const second = new MediaStream();
+  const { container, rerender } = render(<VideoPlayer media={first} />);
+  const element = container.querySelector("video")!;
+
+  expect(element.srcObject).toBe(first);
+
+  rerender(<VideoPlayer media={second} />);
+
+  expect(element.srcObject).toBe(second);
+});

--- a/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
@@ -1,7 +1,13 @@
 import "@testing-library/jest-dom";
 import { userEvent } from "@vitest/browser/context";
 import { render, screen, act, waitFor } from "@testing-library/react";
-import { useMediaDevices } from "../";
+import {
+  useMediaAudioDevices,
+  useMediaAudioInputDevices,
+  useMediaAudioOutputDevices,
+  useMediaDevices,
+  useMediaVideoDevices,
+} from "../";
 
 function AllDevicesTestComponent() {
   const { isReady, devices, request } = useMediaDevices({
@@ -287,6 +293,368 @@ test("clears loading when requesting media devices fails", async () => {
       isReady: false,
       error: requestError.message,
       deviceCount: null,
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("ignores stale enumerateDevices results after a newer request", async () => {
+  const staleRequest = createDeferred<MediaDeviceInfo[]>();
+  const latestRequest = createDeferred<MediaDeviceInfo[]>();
+  const enumerateDevices = vi
+    .fn()
+    .mockReturnValueOnce(staleRequest.promise)
+    .mockReturnValueOnce(latestRequest.promise);
+  const restoreEnumerateDevices = replaceEnumerateDevices(enumerateDevices);
+
+  try {
+    render(<StatusDevicesTestComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      latestRequest.resolve([
+        {
+          ...createMediaDeviceInfo(),
+          deviceId: "latest",
+          label: "Latest Camera",
+        },
+      ]);
+      await latestRequest.promise;
+    });
+
+    expect(readStatus()).toEqual({
+      isLoading: false,
+      isError: false,
+      isReady: true,
+      error: null,
+      deviceCount: 1,
+    });
+    expect(screen.getByTestId("media-devices-status")).toBeTruthy();
+
+    await act(async () => {
+      staleRequest.resolve([
+        {
+          ...createMediaDeviceInfo(),
+          deviceId: "stale",
+          label: "Stale Camera",
+        },
+        createMediaDeviceInfo(),
+      ]);
+      await staleRequest.promise;
+    });
+
+    expect(readStatus()).toEqual({
+      isLoading: false,
+      isError: false,
+      isReady: true,
+      error: null,
+      deviceCount: 1,
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("re-requests devices when devicechange fires", async () => {
+  const first = createDeferred<MediaDeviceInfo[]>();
+  const second = createDeferred<MediaDeviceInfo[]>();
+  const enumerateDevices = vi
+    .fn()
+    .mockReturnValueOnce(first.promise)
+    .mockReturnValueOnce(second.promise);
+  const restoreEnumerateDevices = replaceEnumerateDevices(enumerateDevices);
+
+  try {
+    function DeviceChangeComponent() {
+      const { isReady, devices, request } = useMediaDevices({
+        deviceChangedEvent: true,
+      });
+
+      return (
+        <>
+          <button onClick={() => act(() => request())}>Begin Test</button>
+          <p data-testid="device-count">{devices?.length ?? "none"}</p>
+          <p data-testid="ready">{String(isReady)}</p>
+        </>
+      );
+    }
+
+    render(<DeviceChangeComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      first.resolve([createMediaDeviceInfo()]);
+      await first.promise;
+    });
+
+    expect(await screen.findByTestId("device-count")).toHaveTextContent("1");
+
+    await act(async () => {
+      navigator.mediaDevices.dispatchEvent(new Event("devicechange"));
+      second.resolve([createMediaDeviceInfo(), createMediaDeviceInfo()]);
+      await second.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("device-count")).toHaveTextContent("2");
+    });
+    expect(enumerateDevices).toHaveBeenCalledTimes(2);
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+function createDevice(kind: MediaDeviceInfo["kind"], label: string) {
+  return {
+    ...createMediaDeviceInfo(),
+    deviceId: `${kind}-${label}`,
+    kind,
+    label,
+  } as MediaDeviceInfo;
+}
+
+test("useMediaAudioDevices and useMediaVideoDevices filter by kind", async () => {
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
+
+  try {
+    function FilteredDevicesComponent() {
+      const audio = useMediaAudioDevices({ deviceChangedEvent: false });
+      const video = useMediaVideoDevices({ deviceChangedEvent: false });
+
+      return (
+        <>
+          <button
+            onClick={() =>
+              act(() => {
+                audio.request();
+                video.request();
+              })
+            }
+          >
+            Begin Test
+          </button>
+          <p data-testid="audio-count">{audio.devices?.length ?? "none"}</p>
+          <p data-testid="video-count">{video.devices?.length ?? "none"}</p>
+        </>
+      );
+    }
+
+    render(<FilteredDevicesComponent />);
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      devicesRequest.resolve([
+        createDevice("audioinput", "Mic"),
+        createDevice("audiooutput", "Speakers"),
+        createDevice("videoinput", "Camera"),
+      ]);
+      await devicesRequest.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("audio-count")).toHaveTextContent("2");
+      expect(screen.getByTestId("video-count")).toHaveTextContent("1");
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("useMediaAudioInputDevices and useMediaAudioOutputDevices filter by kind", async () => {
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
+
+  try {
+    function FilteredIODevicesComponent() {
+      const inputs = useMediaAudioInputDevices({ deviceChangedEvent: false });
+      const outputs = useMediaAudioOutputDevices({
+        deviceChangedEvent: false,
+      });
+
+      return (
+        <>
+          <button
+            onClick={() =>
+              act(() => {
+                inputs.request();
+                outputs.request();
+              })
+            }
+          >
+            Begin Test
+          </button>
+          <p data-testid="input-count">{inputs.devices?.length ?? "none"}</p>
+          <p data-testid="output-count">{outputs.devices?.length ?? "none"}</p>
+        </>
+      );
+    }
+
+    render(<FilteredIODevicesComponent />);
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      devicesRequest.resolve([
+        createDevice("audioinput", "Mic"),
+        createDevice("audiooutput", "Speakers"),
+        createDevice("videoinput", "Camera"),
+      ]);
+      await devicesRequest.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("input-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("output-count")).toHaveTextContent("1");
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("surfaces filter exceptions instead of staying loading", async () => {
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
+
+  try {
+    function ThrowingFilterComponent() {
+      const { isLoading, isError, error, request } = useMediaDevices({
+        deviceChangedEvent: false,
+        filter() {
+          throw new Error("filter failed");
+        },
+      });
+
+      return (
+        <>
+          <button onClick={() => act(() => request())}>Begin Test</button>
+          <pre data-testid="media-devices-status">
+            {JSON.stringify({
+              isLoading,
+              isError,
+              isReady: false,
+              error: error?.message ?? null,
+              deviceCount: null,
+            } satisfies MediaDevicesStatus)}
+          </pre>
+        </>
+      );
+    }
+
+    render(<ThrowingFilterComponent />);
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      devicesRequest.resolve([createMediaDeviceInfo()]);
+      await devicesRequest.promise;
+    });
+
+    await waitFor(() => {
+      expect(readStatus()).toEqual({
+        isLoading: false,
+        isError: true,
+        isReady: false,
+        error: "filter failed",
+        deviceCount: null,
+      });
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("ignores stale enumerateDevices rejections after a newer request", async () => {
+  const staleRequest = createDeferred<MediaDeviceInfo[]>();
+  const latestRequest = createDeferred<MediaDeviceInfo[]>();
+  const enumerateDevices = vi
+    .fn()
+    .mockReturnValueOnce(staleRequest.promise)
+    .mockReturnValueOnce(latestRequest.promise);
+  const restoreEnumerateDevices = replaceEnumerateDevices(enumerateDevices);
+
+  try {
+    render(<StatusDevicesTestComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      latestRequest.resolve([createMediaDeviceInfo()]);
+      await latestRequest.promise;
+    });
+
+    expect(readStatus()).toMatchObject({
+      isLoading: false,
+      isError: false,
+      isReady: true,
+      deviceCount: 1,
+    });
+
+    await act(async () => {
+      staleRequest.reject(new Error("stale failure"));
+      await staleRequest.promise.catch(() => undefined);
+    });
+
+    expect(readStatus()).toMatchObject({
+      isLoading: false,
+      isError: false,
+      isReady: true,
+      deviceCount: 1,
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("does not re-request when deviceChangedEvent is false", async () => {
+  const first = createDeferred<MediaDeviceInfo[]>();
+  const enumerateDevices = vi.fn(() => first.promise);
+  const restoreEnumerateDevices = replaceEnumerateDevices(enumerateDevices);
+
+  try {
+    render(<StatusDevicesTestComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    await act(async () => {
+      first.resolve([createMediaDeviceInfo()]);
+      await first.promise;
+    });
+
+    await act(async () => {
+      navigator.mediaDevices.dispatchEvent(new Event("devicechange"));
+    });
+
+    expect(enumerateDevices).toHaveBeenCalledTimes(1);
+  } finally {
+    restoreEnumerateDevices();
+  }
+});
+
+test("ignores enumerateDevices results after unmount", async () => {
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
+
+  try {
+    const { unmount } = render(<StatusDevicesTestComponent />);
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+    unmount();
+
+    await act(async () => {
+      devicesRequest.resolve([createMediaDeviceInfo()]);
+      await devicesRequest.promise;
     });
   } finally {
     restoreEnumerateDevices();

--- a/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-devices.spec.tsx
@@ -660,3 +660,58 @@ test("ignores enumerateDevices results after unmount", async () => {
     restoreEnumerateDevices();
   }
 });
+
+test("applies the latest filter when a pending request resolves", async () => {
+  const devicesRequest = createDeferred<MediaDeviceInfo[]>();
+  const restoreEnumerateDevices = replaceEnumerateDevices(
+    vi.fn(() => devicesRequest.promise),
+  );
+
+  try {
+    function ChangingFilterComponent({
+      filter,
+    }: {
+      filter: (device: MediaDeviceInfo) => boolean;
+    }) {
+      const { isReady, devices, request } = useMediaDevices({
+        deviceChangedEvent: false,
+        filter,
+      });
+
+      return (
+        <>
+          <button onClick={() => act(() => request())}>Begin Test</button>
+          <p data-testid="device-count">{devices?.length ?? "none"}</p>
+          <p data-testid="ready">{String(isReady)}</p>
+        </>
+      );
+    }
+
+    const { rerender } = render(
+      <ChangingFilterComponent filter={() => true} />,
+    );
+
+    await userEvent.click(await screen.findByText("Begin Test"));
+
+    rerender(
+      <ChangingFilterComponent
+        filter={(device) => device.kind === "audioinput"}
+      />,
+    );
+
+    await act(async () => {
+      devicesRequest.resolve([
+        createDevice("audioinput", "Mic"),
+        createDevice("videoinput", "Camera"),
+      ]);
+      await devicesRequest.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ready")).toHaveTextContent("true");
+      expect(screen.getByTestId("device-count")).toHaveTextContent("1");
+    });
+  } finally {
+    restoreEnumerateDevices();
+  }
+});

--- a/packages/react-user-media/src/hooks/use-media-devices.ts
+++ b/packages/react-user-media/src/hooks/use-media-devices.ts
@@ -123,6 +123,8 @@ export function useMediaDevices(
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const requestGeneration = useRef(0);
+  const filterRef = useRef(filter);
+  filterRef.current = filter;
 
   const isError = useMemo(() => error !== null, [error]);
   const isReady = useMemo(() => typeof devices !== "undefined", [devices]);
@@ -156,7 +158,7 @@ export function useMediaDevices(
           }
 
           try {
-            setDevices(devices.filter(filter));
+            setDevices(devices.filter(filterRef.current));
             setError(null);
             setIsLoading(false);
           } catch (error) {
@@ -176,7 +178,7 @@ export function useMediaDevices(
         },
       );
     },
-    [filter],
+    [],
   );
 
   useEffect(

--- a/packages/react-user-media/src/hooks/use-media-devices.ts
+++ b/packages/react-user-media/src/hooks/use-media-devices.ts
@@ -1,5 +1,9 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { ShallowShapeOf } from "../types";
+
+function toError(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 /**
  * The base state of {@link useMediaDevices} response.
@@ -118,12 +122,16 @@ export function useMediaDevices(
   );
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const requestGeneration = useRef(0);
 
   const isError = useMemo(() => error !== null, [error]);
   const isReady = useMemo(() => typeof devices !== "undefined", [devices]);
 
   const request = useCallback(
     function requestMediaDevices() {
+      const currentRequestGeneration = requestGeneration.current + 1;
+      requestGeneration.current = currentRequestGeneration;
+
       const mediaDevices = navigator.mediaDevices;
 
       if (!mediaDevices?.enumerateDevices) {
@@ -143,12 +151,26 @@ export function useMediaDevices(
 
       mediaDevices.enumerateDevices().then(
         function onRequestSuccess(devices) {
-          setDevices(devices.filter(filter));
-          setError(null);
-          setIsLoading(false);
+          if (requestGeneration.current !== currentRequestGeneration) {
+            return;
+          }
+
+          try {
+            setDevices(devices.filter(filter));
+            setError(null);
+            setIsLoading(false);
+          } catch (error) {
+            setError(toError(error));
+            setDevices(undefined);
+            setIsLoading(false);
+          }
         },
         function onRequestError(error) {
-          setError(error);
+          if (requestGeneration.current !== currentRequestGeneration) {
+            return;
+          }
+
+          setError(toError(error));
           setDevices(undefined);
           setIsLoading(false);
         },
@@ -177,6 +199,12 @@ export function useMediaDevices(
     },
     [deviceChangedEvent, request],
   );
+
+  useEffect(function invalidateRequestsOnUnmount() {
+    return function teardown() {
+      requestGeneration.current += 1;
+    };
+  }, []);
 
   const state = {
     isError,

--- a/packages/react-user-media/src/hooks/use-media-ext.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-ext.spec.tsx
@@ -149,3 +149,35 @@ test("keeps video track references stable when only audio tracks change", async 
 
   expect(result.current).toBe(videoTracks);
 });
+
+test("returns a frozen empty array for an empty MediaStream", () => {
+  const media = new MediaStream();
+  const { result } = renderHook(() => useMediaTracks(media));
+
+  expect(result.current).toEqual([]);
+  expect(Object.isFrozen(result.current)).toBe(true);
+});
+
+test("ignores track events from a previous media stream after rerender", async () => {
+  const firstTrack = await createTrack("audio");
+  const secondTrack = await createTrack("audio");
+  const firstMedia = new MediaStream([firstTrack]);
+  const secondMedia = new MediaStream([secondTrack]);
+  const { result, rerender } = renderHook(
+    ({ currentMedia }: { currentMedia: MediaStream }) =>
+      useMediaTracks(currentMedia),
+    { initialProps: { currentMedia: firstMedia } },
+  );
+
+  expect(result.current).toEqual([firstTrack]);
+
+  rerender({ currentMedia: secondMedia });
+  expect(result.current).toEqual([secondTrack]);
+
+  act(() => {
+    firstMedia.removeTrack(firstTrack);
+    dispatchTrackEvent(firstMedia, "removetrack");
+  });
+
+  expect(result.current).toEqual([secondTrack]);
+});

--- a/packages/react-user-media/src/hooks/use-media-ext.ts
+++ b/packages/react-user-media/src/hooks/use-media-ext.ts
@@ -73,7 +73,7 @@ function useMediaTracksByKind(
  * @returns an array of {@link MediaStreamTrack}s.
  */
 export function useMediaTracks(media: MediaStream | undefined) {
-  const trackCache = useRef<MediaStreamTrack[]>([]);
+  const trackCache = useRef<MediaStreamTrack[]>(EMPTY_TRACKS);
 
   return useSyncExternalStore(
     useCallback(

--- a/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-recorder.spec.tsx
@@ -7,6 +7,8 @@ const mockStream = new MediaStream();
 
 class MockMediaRecorder extends EventTarget {
   static instances: MockMediaRecorder[] = [];
+  static throwOnConstruct: Error | null = null;
+  static throwOnStart: Error | null = null;
 
   readonly startCalls: unknown[][] = [];
   readonly listenerCounts = new Map<string, number>();
@@ -17,6 +19,10 @@ class MockMediaRecorder extends EventTarget {
 
   constructor(media: MediaStream, options?: MediaRecorderOptions) {
     super();
+
+    if (MockMediaRecorder.throwOnConstruct) {
+      throw MockMediaRecorder.throwOnConstruct;
+    }
 
     this.media = media;
     this.options = options;
@@ -45,6 +51,10 @@ class MockMediaRecorder extends EventTarget {
   }
 
   start(...args: unknown[]) {
+    if (MockMediaRecorder.throwOnStart) {
+      throw MockMediaRecorder.throwOnStart;
+    }
+
     this.startCalls.push(args);
     this.state = "recording";
     this.dispatchEvent(new Event("start"));
@@ -60,12 +70,34 @@ class MockMediaRecorder extends EventTarget {
     this.dispatchEvent(new Event("stop"));
   }
 
+  pause() {
+    if (this.state !== "recording") {
+      return;
+    }
+
+    this.state = "paused";
+    this.dispatchEvent(new Event("pause"));
+  }
+
+  resume() {
+    if (this.state !== "paused") {
+      return;
+    }
+
+    this.state = "recording";
+    this.dispatchEvent(new Event("resume"));
+  }
+
   dispatchData(data: Blob) {
     this.dispatchEvent(new BlobEvent("dataavailable", { data }));
   }
 
-  dispatchRecorderError() {
-    this.dispatchEvent(new Event("error"));
+  dispatchRecorderError(error?: Error) {
+    const event = new Event("error") as Event & { error?: Error };
+    if (error) {
+      event.error = error;
+    }
+    this.dispatchEvent(event);
   }
 }
 
@@ -85,10 +117,18 @@ function RecorderLifecycleTestComponent() {
         Start With Timeslice
       </button>
       <button onClick={() => act(() => recorder.stopRecording())}>Stop</button>
+      <button onClick={() => act(() => recorder.pauseRecording())}>
+        Pause
+      </button>
+      <button onClick={() => act(() => recorder.resumeRecording())}>
+        Resume
+      </button>
       <p data-testid="is-error">{String(recorder.isError)}</p>
       <p data-testid="is-finalized">{String(recorder.isFinalized)}</p>
       <p data-testid="is-recording">{String(recorder.isRecording)}</p>
+      <p data-testid="is-paused">{String(recorder.isPaused)}</p>
       <p data-testid="segments-length">{recorder.segments.length}</p>
+      <p data-testid="error-message">{recorder.error?.message ?? "none"}</p>
     </>
   );
 }
@@ -98,6 +138,8 @@ describe("useMediaRecorder lifecycle", () => {
 
   beforeEach(() => {
     MockMediaRecorder.instances = [];
+    MockMediaRecorder.throwOnConstruct = null;
+    MockMediaRecorder.throwOnStart = null;
     Object.defineProperty(globalThis, "MediaRecorder", {
       configurable: true,
       writable: true,
@@ -270,6 +312,88 @@ describe("useMediaRecorder lifecycle", () => {
       expect(screen.getByTestId("is-finalized")).toHaveTextContent("true"),
     );
     expect(screen.getByTestId("segments-length")).toHaveTextContent("0");
+  });
+
+  test("pause and resume toggle isPaused and isRecording", async () => {
+    render(<RecorderLifecycleTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start"));
+    await waitFor(() =>
+      expect(screen.getByTestId("is-recording")).toHaveTextContent("true"),
+    );
+    expect(screen.getByTestId("is-paused")).toHaveTextContent("false");
+
+    await userEvent.click(await screen.findByText("Pause"));
+    await waitFor(() => {
+      expect(screen.getByTestId("is-paused")).toHaveTextContent("true");
+      expect(screen.getByTestId("is-recording")).toHaveTextContent("false");
+      expect(screen.getByTestId("is-finalized")).toHaveTextContent("false");
+    });
+
+    await userEvent.click(await screen.findByText("Resume"));
+    await waitFor(() => {
+      expect(screen.getByTestId("is-paused")).toHaveTextContent("false");
+      expect(screen.getByTestId("is-recording")).toHaveTextContent("true");
+    });
+  });
+
+  test("surfaces MediaRecorder constructor failures as isError", async () => {
+    MockMediaRecorder.throwOnConstruct = new Error("unsupported mimeType");
+
+    render(<RecorderLifecycleTestComponent />);
+
+    expect(() => {
+      act(() => {
+        screen.getByText("Start").click();
+      });
+    }).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-error")).toHaveTextContent("true");
+      expect(screen.getByTestId("error-message")).toHaveTextContent(
+        "unsupported mimeType",
+      );
+      expect(screen.getByTestId("is-recording")).toHaveTextContent("false");
+    });
+    expect(MockMediaRecorder.instances).toHaveLength(0);
+  });
+
+  test("surfaces recorder.start failures as isError", async () => {
+    MockMediaRecorder.throwOnStart = new Error("start failed");
+
+    render(<RecorderLifecycleTestComponent />);
+
+    expect(() => {
+      act(() => {
+        screen.getByText("Start").click();
+      });
+    }).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-error")).toHaveTextContent("true");
+      expect(screen.getByTestId("error-message")).toHaveTextContent(
+        "start failed",
+      );
+      expect(screen.getByTestId("is-recording")).toHaveTextContent("false");
+    });
+  });
+
+  test("preserves native MediaRecorder error details", async () => {
+    render(<RecorderLifecycleTestComponent />);
+
+    await userEvent.click(await screen.findByText("Start"));
+
+    const nativeError = new DOMException("encoder failed", "EncodingError");
+    act(() => {
+      MockMediaRecorder.instances[0]?.dispatchRecorderError(nativeError);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("is-error")).toHaveTextContent("true");
+      expect(screen.getByTestId("error-message")).toHaveTextContent(
+        "encoder failed",
+      );
+    });
   });
 });
 

--- a/packages/react-user-media/src/hooks/use-media-recorder.ts
+++ b/packages/react-user-media/src/hooks/use-media-recorder.ts
@@ -255,7 +255,21 @@ export function useMediaRecorder(): RecorderState {
       ...recorderOptions
     } = options ?? {};
 
-    const recorder = new MediaRecorder(media, recorderOptions);
+    let recorder: MediaRecorder;
+
+    try {
+      recorder = new MediaRecorder(media, recorderOptions);
+    } catch (error) {
+      setError(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      setSegments([]);
+      setEndTime(null);
+      setStartTime(null);
+      setRecorder(null);
+      return;
+    }
+
     const sessionId = sessionIdRef.current;
 
     const onDataAvailable = function onDataAvailable(ev: BlobEvent) {
@@ -288,10 +302,24 @@ export function useMediaRecorder(): RecorderState {
 
     const startTime = performance.now();
 
-    if (timeslice === undefined) {
-      recorder.start();
-    } else {
-      recorder.start(timeslice);
+    try {
+      if (timeslice === undefined) {
+        recorder.start();
+      } else {
+        recorder.start(timeslice);
+      }
+    } catch (error) {
+      cleanupRecorderRef.current?.();
+      cleanupRecorderRef.current = null;
+      recorderRef.current = null;
+      setError(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      setSegments([]);
+      setEndTime(null);
+      setStartTime(null);
+      setRecorder(null);
+      return;
     }
 
     setStartTime(startTime);
@@ -427,21 +455,28 @@ function useMediaRecorderError(
       const sessionId = sessionIdRef.current;
       let isCurrentSubscription = true;
 
-      setErrorState(null);
-
       if (!recorder) {
         return function teardown() {
           isCurrentSubscription = false;
         };
       }
 
-      const onError = () => {
+      // Clear prior error state only when observing a new recorder.
+      // Failed starts may set an error while `recorder` remains null.
+      setErrorState(null);
+
+      const onError = (event: Event) => {
         if (!isCurrentSubscription || sessionIdRef.current !== sessionId) {
           return;
         }
 
+        const eventError =
+          "error" in event && event.error instanceof Error
+            ? event.error
+            : new Error(`MediaRecorder encountered an unknown error.`);
+
         setErrorState({
-          error: new Error(`MediaRecorder encountered an unknown error.`),
+          error: eventError,
           sessionId,
         });
       };

--- a/packages/react-user-media/src/hooks/use-media.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media.spec.tsx
@@ -259,3 +259,48 @@ test("requests display media", async () => {
     });
   }
 });
+
+test("surfaces synchronous getUserMedia failures", async () => {
+  vi.spyOn(navigator.mediaDevices, "getUserMedia").mockImplementation(() => {
+    throw new Error("sync getUserMedia failure");
+  });
+
+  render(<UserMediaTestComponent />);
+
+  expect(() => {
+    act(() => {
+      screen.getByText("Request").click();
+    });
+  }).not.toThrow();
+
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("error");
+    expect(screen.getByTestId("error-message")).toHaveTextContent(
+      "sync getUserMedia failure",
+    );
+  });
+});
+
+test("closes streams that resolve after unmount", async () => {
+  const stream = createFakeMediaStream("late");
+  const deferred = createDeferredMediaStream();
+  vi.spyOn(navigator.mediaDevices, "getUserMedia").mockReturnValueOnce(
+    deferred.promise,
+  );
+
+  const { unmount } = render(<UserMediaTestComponent />);
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  unmount();
+
+  await act(async () => {
+    deferred.resolve(stream.media);
+    await deferred.promise;
+  });
+
+  expect(stream.track.stop).toHaveBeenCalledTimes(1);
+  expect(stream.track.readyState).toBe("ended");
+});

--- a/packages/react-user-media/src/hooks/use-media.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media.spec.tsx
@@ -304,3 +304,51 @@ test("closes streams that resolve after unmount", async () => {
   expect(stream.track.stop).toHaveBeenCalledTimes(1);
   expect(stream.track.readyState).toBe("ended");
 });
+
+test("ignores in-flight user media after type changes to display", async () => {
+  const userStream = createFakeMediaStream("user");
+  const deferred = createDeferredMediaStream();
+  vi.spyOn(navigator.mediaDevices, "getUserMedia").mockReturnValueOnce(
+    deferred.promise,
+  );
+
+  function SwitchingTypeComponent({
+    type,
+  }: {
+    type: "user" | "display";
+  }) {
+    const { isReady, isLoading, media, request } = useMedia(type);
+
+    return (
+      <>
+        <button onClick={() => request({ video: true })}>Request</button>
+        <p data-testid="switch-state">
+          {isReady ? "ready" : isLoading ? "loading" : "idle"}
+        </p>
+        <p data-testid="switch-media-id">{media?.id ?? "none"}</p>
+      </>
+    );
+  }
+
+  const { rerender } = render(<SwitchingTypeComponent type="user" />);
+
+  act(() => {
+    screen.getByText("Request").click();
+  });
+
+  expect(screen.getByTestId("switch-state")).toHaveTextContent("loading");
+
+  rerender(<SwitchingTypeComponent type="display" />);
+
+  expect(screen.getByTestId("switch-state")).toHaveTextContent("idle");
+  expect(screen.getByTestId("switch-media-id")).toHaveTextContent("none");
+
+  await act(async () => {
+    deferred.resolve(userStream.media);
+    await deferred.promise;
+  });
+
+  expect(userStream.track.stop).toHaveBeenCalledTimes(1);
+  expect(screen.getByTestId("switch-state")).toHaveTextContent("idle");
+  expect(screen.getByTestId("switch-media-id")).toHaveTextContent("none");
+});

--- a/packages/react-user-media/src/hooks/use-media.ts
+++ b/packages/react-user-media/src/hooks/use-media.ts
@@ -220,6 +220,7 @@ export function useMedia<
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const mediaRef = useRef<MediaStream | undefined>(undefined);
   const requestGeneration = useRef(0);
+  const typeRef = useRef(type);
 
   const isError = useMemo(() => error !== null, [error]);
   const isReady = useMemo(() => typeof media !== "undefined", [media]);
@@ -232,6 +233,23 @@ export function useMedia<
     setError(null);
     setIsLoading(false);
   }, []);
+
+  useEffect(
+    function resetWhenTypeChanges() {
+      if (typeRef.current === type) {
+        return;
+      }
+
+      typeRef.current = type;
+      requestGeneration.current += 1;
+      closeMedia(mediaRef.current);
+      mediaRef.current = undefined;
+      setMedia(undefined);
+      setError(null);
+      setIsLoading(false);
+    },
+    [type],
+  );
 
   const request = useCallback(
     function requestUserMedia(

--- a/packages/react-user-media/src/hooks/use-media.ts
+++ b/packages/react-user-media/src/hooks/use-media.ts
@@ -268,67 +268,52 @@ export function useMedia<
       setMedia(undefined);
       setError(null);
 
-      switch (type) {
-        case "user":
-          navigator.mediaDevices
-            .getUserMedia(...args)
-            .then(
-              function onRequestSuccess(userMedia) {
-                if (requestGeneration.current !== currentRequestGeneration) {
-                  closeMedia(userMedia);
-                  return;
-                }
+      function onRequestSuccess(userMedia: MediaStream) {
+        if (requestGeneration.current !== currentRequestGeneration) {
+          closeMedia(userMedia);
+          return;
+        }
 
-                mediaRef.current = userMedia;
-                setMedia(userMedia);
-                setError(null);
-              },
-              function onRequestError(error) {
-                if (requestGeneration.current !== currentRequestGeneration) {
-                  return;
-                }
+        mediaRef.current = userMedia;
+        setMedia(userMedia);
+        setError(null);
+      }
 
-                setError(toError(error));
-                setMedia(undefined);
-              },
-            )
-            .then(function finalizeRequest() {
-              if (requestGeneration.current === currentRequestGeneration) {
-                setIsLoading(false);
-              }
-            });
-          break;
-        case "display":
-          navigator.mediaDevices
-            .getDisplayMedia(...args)
-            .then(
-              function onRequestSuccess(userMedia) {
-                if (requestGeneration.current !== currentRequestGeneration) {
-                  closeMedia(userMedia);
-                  return;
-                }
+      function onRequestError(error: unknown) {
+        if (requestGeneration.current !== currentRequestGeneration) {
+          return;
+        }
 
-                mediaRef.current = userMedia;
-                setMedia(userMedia);
-                setError(null);
-              },
-              function onRequestError(error) {
-                if (requestGeneration.current !== currentRequestGeneration) {
-                  return;
-                }
+        setError(toError(error));
+        setMedia(undefined);
+      }
 
-                setError(toError(error));
-                setMedia(undefined);
-              },
-            )
-            .then(function finalizeRequest() {
-              if (requestGeneration.current === currentRequestGeneration) {
-                setIsLoading(false);
-              }
-            });
-          break;
-        default:
-          (type) satisfies never;
+      function finalizeRequest() {
+        if (requestGeneration.current === currentRequestGeneration) {
+          setIsLoading(false);
+        }
+      }
+
+      try {
+        switch (type) {
+          case "user":
+            navigator.mediaDevices
+              .getUserMedia(...args)
+              .then(onRequestSuccess, onRequestError)
+              .then(finalizeRequest);
+            break;
+          case "display":
+            navigator.mediaDevices
+              .getDisplayMedia(...args)
+              .then(onRequestSuccess, onRequestError)
+              .then(finalizeRequest);
+            break;
+          default:
+            (type) satisfies never;
+        }
+      } catch (error) {
+        onRequestError(error);
+        finalizeRequest();
       }
     },
     [type],

--- a/packages/react-user-media/src/hooks/use-track-mute-state.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-track-mute-state.spec.tsx
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useTrackMuteState } from "../";
+
+function createTrack(muted: boolean) {
+  const track = new EventTarget() as EventTarget & {
+    muted: boolean;
+  };
+  track.muted = muted;
+  return track as unknown as MediaStreamTrack;
+}
+
+test("useTrackMuteState reflects muted and unmute events", async () => {
+  const track = createTrack(false);
+  const { result } = renderHook(() => useTrackMuteState(track));
+
+  expect(result.current).toBe("unmuted");
+
+  await act(async () => {
+    track.muted = true;
+    track.dispatchEvent(new Event("mute"));
+  });
+
+  await waitFor(() => {
+    expect(result.current).toBe("muted");
+  });
+
+  await act(async () => {
+    track.muted = false;
+    track.dispatchEvent(new Event("unmute"));
+  });
+
+  await waitFor(() => {
+    expect(result.current).toBe("unmuted");
+  });
+});
+
+test("useTrackMuteState starts muted when the track is muted", () => {
+  const track = createTrack(true);
+  const { result } = renderHook(() => useTrackMuteState(track));
+
+  expect(result.current).toBe("muted");
+});
+
+test("useTrackMuteState ignores mute events from a previous track", async () => {
+  const first = createTrack(false);
+  const second = createTrack(false);
+  const { result, rerender } = renderHook(
+    ({ track }: { track: MediaStreamTrack }) => useTrackMuteState(track),
+    { initialProps: { track: first } },
+  );
+
+  expect(result.current).toBe("unmuted");
+
+  rerender({ track: second });
+
+  await act(async () => {
+    first.muted = true;
+    first.dispatchEvent(new Event("mute"));
+  });
+
+  expect(result.current).toBe("unmuted");
+
+  await act(async () => {
+    second.muted = true;
+    second.dispatchEvent(new Event("mute"));
+  });
+
+  await waitFor(() => {
+    expect(result.current).toBe("muted");
+  });
+});

--- a/packages/react-user-media/src/index.ts
+++ b/packages/react-user-media/src/index.ts
@@ -3,5 +3,7 @@ export * from "./components";
 export * from "./close-media";
 
 export function getSupportedConstraints() {
-  return navigator.mediaDevices?.getSupportedConstraints?.() ?? {};
+  return (
+    globalThis.navigator?.mediaDevices?.getSupportedConstraints?.() ?? {}
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up correctness pass after the earlier lifecycle fixes. This hardens remaining failure/race paths and adds regression tests around under-covered behaviors.

### Fixes
- **`useMediaDevices`**: ignore stale `enumerateDevices` success/error after a newer request or unmount; surface thrown filters via `error` instead of staying loading; apply the **latest** filter when a pending request resolves
- **`useMedia`**: catch synchronous `getUserMedia` / `getDisplayMedia` failures and clear loading; **reset and invalidate** in-flight requests when `type` changes
- **`useMediaRecorder`**: catch `MediaRecorder` constructor / `start()` throws into `isError`; preserve native recorder error details; avoid clearing sync start errors when recorder stays `null`
- **`useMediaTracks`**: return the frozen empty snapshot for empty streams
- **`getSupportedConstraints`**: tolerate missing `navigator`

### Tests
- Devices: stale race, stale rejection, `devicechange`, filters (audio/video/input/output), filter exceptions, unmount, latest-filter-on-pending-resolve
- Media: sync failure, late resolve after unmount, type change while in-flight
- Recorder: constructor/start failures, native error details, pause/resume
- Tracks / mute / players / `closeMedia` helpers

### Verification
- `pnpm build && pnpm test` in `packages/react-user-media`: **59 passed**
- CI build on the PR branch was green for the first revision; this push adds the review follow-ups

### Review notes
Independent review found no critical issues. Two important input-change races (type / filter mid-flight) were fixed in a follow-up commit on this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8f37-7223-7f9f-961a-e672a6d986f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

