### PR TITLE
docs: add OpenSpec baselines for existing media APIs

### DIFF
--- a/openspec/changes/baseline-media-capture/.openspec.yaml
+++ b/openspec/changes/baseline-media-capture/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/baseline-media-capture/design.md
+++ b/openspec/changes/baseline-media-capture/design.md
@@ -1,0 +1,105 @@
+## Context
+
+`@bengreenier/react-user-media` already implements media capture in `packages/react-user-media`:
+
+- `useMedia` (`src/hooks/use-media.ts`) — React hook over `getUserMedia` / `getDisplayMedia`
+- `closeMedia` (`src/close-media.ts`) — stop all tracks on a stream
+- `getSupportedConstraints` (`src/index.ts`) — thin, null-safe wrapper around `mediaDevices.getSupportedConstraints`
+
+This design records the **as-built** architecture so future OpenSpec deltas can reason about lifecycle and API contracts. No new implementation is proposed.
+
+Covered tests live in `use-media.spec.tsx` and `close-media.spec.ts` (Vitest + Testing Library, browser-oriented mocks).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Document how media acquisition, discriminated state, request generations, and cleanup work today
+- Make the public surface and lifecycle guarantees explicit for baselining
+- Align design language with existing tests and TypeScript types
+
+**Non-Goals:**
+
+- Redesigning the hook API or state machine
+- Adding workers, WebCodecs, device enumeration, or MediaRecorder into this capability
+- Changing cleanup semantics or introducing new dependencies
+- Migrating runtime behavior; this change is documentation-only
+
+## Decisions
+
+### 1. Single hook with a type discriminant
+
+**Choice:** One `useMedia(type)` entry point where `type` is `"user" | "display"`, rather than separate hooks.
+
+**Rationale (as-built):** Shared loading/error/ready machinery and identical cleanup rules; TypeScript conditional types (`inferMediaDef`) specialize `request` argument and return state per type.
+
+**Alternatives considered:** Separate `useUserMedia` / `useDisplayMedia` hooks — not used; would duplicate generation and teardown logic.
+
+### 2. Discriminated boolean flags + cast return
+
+**Choice:** Internal state is three React state fields (`media`, `error`, `isLoading`) plus derived `isReady` / `isError`. The return value is typed as a discriminated union but assembled as one object and cast (`as inferMediaDef<TType>["stateType"]`).
+
+**Rationale:** Avoids runtime branching cost while preserving a strong consumer-facing type. Flags remain mutually exclusive by construction of setters.
+
+**Alternatives considered:** Explicit tagged union in runtime state (`status: "idle" | ...`) — not used in current code.
+
+### 3. Request generations for async correctness
+
+**Choice:** A mutable `requestGeneration` ref increments on every `request`, `stop`, `type` change, and unmount. Success/error/finalize handlers ignore mismatched generations; successful-but-stale streams are passed to `closeMedia`.
+
+**Rationale:** Media promises outlive React renders; without generations, late resolutions would leak tracks or overwrite newer media (covered by stale / unmount / type-change tests).
+
+**Alternatives considered:** AbortController on constraints APIs — not universally available / not used here; generation counter is sufficient for ignore-and-close.
+
+### 4. Eager close of prior stream on re-request
+
+**Choice:** At the start of `request`, call `closeMedia(mediaRef.current)` and clear ref/state media before invoking the browser API.
+
+**Rationale:** Prevents overlapping live tracks when the consumer re-requests; matches “stops the previous user media stream when re-requesting” test.
+
+### 5. Type change resets like stop (without requiring consumer action)
+
+**Choice:** An effect compares `type` to `typeRef`; on change, bump generation, close held media, and clear to idle.
+
+**Rationale:** Switching `"user"` ↔ `"display"` must not keep the wrong stream or apply a late user promise to a display hook instance.
+
+### 6. Unmount teardown closes tracks only
+
+**Choice:** Cleanup effect bumps generation and `closeMedia`s the ref; it does not set React state (component is gone).
+
+**Rationale:** Avoids setState-after-unmount while still ending tracks and invalidating in-flight handlers.
+
+### 7. Capability checks before promise
+
+**Choice:** If the matching capture API is missing, set a descriptive `Error` and skip `setIsLoading(true)` / promise path.
+
+**Rationale:** Fail closed in non-secure or incomplete environments without throwing from `request`.
+
+### 8. Shared `closeMedia` helper
+
+**Choice:** Centralize `media?.getTracks().forEach(track => track.stop())`.
+
+**Rationale:** One place for teardown used by the hook; undefined-safe for idle paths.
+
+### 9. Null-safe `getSupportedConstraints`
+
+**Choice:** Optional chaining through `globalThis.navigator?.mediaDevices?.getSupportedConstraints?.()` with `?? {}`.
+
+**Rationale:** Safe to call during SSR or degraded environments; returns empty constraint map rather than throwing.
+
+## Risks / Trade-offs
+
+- **[Risk] Cast return can drift from true discriminant invariants** → Mitigation: keep tests asserting exclusive idle/loading/ready/error presentations; prefer not widening setters.
+- **[Risk] Generation counter is process-local and silent** → Mitigation: always `closeMedia` on stale success so leaks are prevented even when state updates are skipped.
+- **[Risk] No AbortSignal** → Mitigation: superseded requests may still complete in the browser; library closes unused streams on resolve. Consumers should still prefer `stop` / unmount for intentional teardown.
+- **[Risk] Baseline docs can drift from code** → Mitigation: verification tasks audit scenarios against `use-media.spec.tsx` / `close-media.spec.ts` before treating archive as source of truth.
+- **[Trade-off] Single object + cast vs runtime tagged state** → Favor typing ergonomics and less boilerplate; correctness relies on disciplined updates and tests.
+
+## Migration Plan
+
+Not applicable for runtime. After archive/sync, main specs under `openspec/specs/media-capture/` SHOULD mirror this baseline so later changes use MODIFIED/ADDED deltas. No rollback beyond deleting or revising these planning artifacts.
+
+## Open Questions
+
+- Whether to promote this capability into `openspec/specs/` immediately after validation (optional; listed as a verification task, not required for apply-ready planning).
+- Whether future deltas should add an explicit runtime `status` discriminant (out of scope for this baseline).

--- a/openspec/changes/baseline-media-capture/proposal.md
+++ b/openspec/changes/baseline-media-capture/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The library already ships `useMedia`, `closeMedia`, and `getSupportedConstraints` for browser media capture, but there is no OpenSpec baseline for that behavior. Documenting it as-built gives future deltas a stable contract for lifecycle, cleanup, and API surface without changing runtime behavior.
+
+## What Changes
+
+- Add an OpenSpec capability `media-capture` that records existing requirements for:
+  - `useMedia("user" | "display")` → `getUserMedia` / `getDisplayMedia`
+  - Discriminated idle → loading → ready | error state, plus `request` / `stop`
+  - Request generations, stream close on re-request / type change / unmount
+  - `closeMedia` and `getSupportedConstraints`
+- No application code, API, or test behavior changes.
+
+## Non-goals
+
+- Implementing or refactoring hooks, helpers, or examples
+- Changing public API signatures or state shape
+- Adding workers, WebCodecs, or MediaRecorder coverage
+- Expanding browser support beyond what already exists
+- Syncing into `openspec/specs/` as part of this change (optional follow-up)
+
+## Capabilities
+
+### New Capabilities
+
+- `media-capture`: React hook and helpers for obtaining, managing, and releasing user/display `MediaStream`s, including lifecycle correctness and constraint discovery.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- Planning only: artifacts under `openspec/changes/baseline-media-capture/`
+- Documents existing code in `packages/react-user-media` (`use-media.ts`, `close-media.ts`, `index.ts`) and tests (`use-media.spec.tsx`, `close-media.spec.ts`)
+- No package publish or dependency impact

--- a/openspec/changes/baseline-media-capture/specs/media-capture/spec.md
+++ b/openspec/changes/baseline-media-capture/specs/media-capture/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: User and display media acquisition
+`useMedia` MUST accept a `type` of `"user"` or `"display"`. When `type` is `"user"`, `request` MUST obtain media via `navigator.mediaDevices.getUserMedia`. When `type` is `"display"`, `request` MUST obtain media via `navigator.mediaDevices.getDisplayMedia`. Optional request arguments MUST be forwarded to the corresponding browser API (`MediaStreamConstraints` for user, `DisplayMediaStreamOptions` for display).
+
+#### Scenario: User media request uses getUserMedia
+- **WHEN** a consumer calls `useMedia("user")` and invokes `request` with constraints
+- **THEN** the hook MUST call `navigator.mediaDevices.getUserMedia` with those constraints
+- **AND** on success enter the ready state with the returned `MediaStream`
+
+#### Scenario: Display media request uses getDisplayMedia
+- **WHEN** a consumer calls `useMedia("display")` and invokes `request` with options (for example `{ video: true }`)
+- **THEN** the hook MUST call `navigator.mediaDevices.getDisplayMedia` with those options
+- **AND** on success enter the ready state with the returned `MediaStream`
+
+### Requirement: Discriminated media state
+`useMedia` MUST expose a discriminated state shape with mutually exclusive idle, loading, ready, and error modes, plus `request` and `stop` actions on every mode.
+
+- Idle: `isLoading: false`, `isError: false`, `isReady: false`, `error: null`, `media: undefined`
+- Loading: `isLoading: true`, `isError: false`, `isReady: false`, `error: null`, `media: undefined`
+- Ready: `isLoading: false`, `isError: false`, `isReady: true`, `error: null`, `media: MediaStream`
+- Error: `isLoading: false`, `isError: true`, `isReady: false`, `error: Error`, `media: undefined`
+
+#### Scenario: Initial state is idle
+- **WHEN** `useMedia` mounts before any `request`
+- **THEN** the returned state MUST be idle (`isReady`, `isLoading`, and `isError` all false; `media` undefined; `error` null)
+
+#### Scenario: Request transitions through loading to ready
+- **WHEN** `request` is invoked and the browser media promise resolves with a stream
+- **THEN** state MUST first reflect loading while the request is in flight
+- **AND** then reflect ready with that stream as `media`
+
+#### Scenario: Request failure yields error state
+- **WHEN** `getUserMedia` rejects or throws synchronously
+- **THEN** the hook MUST NOT throw to the caller
+- **AND** state MUST become error with a non-null `Error` and undefined `media`
+
+#### Scenario: Missing getUserMedia capability yields error
+- **WHEN** `type` is `"user"` and `navigator.mediaDevices.getUserMedia` is unavailable
+- **THEN** invoking `request` MUST set error state with a message indicating getUserMedia is not available
+- **AND** MUST NOT throw
+
+#### Scenario: Missing getDisplayMedia capability yields error
+- **WHEN** `type` is `"display"` and `navigator.mediaDevices.getDisplayMedia` is unavailable
+- **THEN** invoking `request` MUST set error state with a message indicating getDisplayMedia is not available
+- **AND** MUST NOT throw
+
+### Requirement: Stop returns to idle and releases media
+`stop` MUST increment the request generation, stop tracks on the current stream via `closeMedia`, clear `media` and `error`, clear loading, and return the hook to idle.
+
+#### Scenario: Stop clears ready user media
+- **WHEN** the hook is ready with an active stream and the consumer calls `stop`
+- **THEN** every track on that stream MUST be stopped
+- **AND** state MUST return to idle with `media` undefined
+
+### Requirement: Re-request closes the previous stream
+When `request` is invoked while a prior stream is held, the hook MUST close the prior stream before starting the new acquisition.
+
+#### Scenario: Re-request stops previous user media stream
+- **WHEN** the hook is ready with stream A and the consumer calls `request` again
+- **THEN** tracks on stream A MUST be stopped before stream B becomes ready
+- **AND** ready state MUST expose stream B
+
+### Requirement: Stale in-flight requests must not leak or overwrite newer state
+The hook MUST track request generations so that outcomes from superseded requests do not replace newer media or loading/error state. Streams that resolve after being superseded MUST be closed.
+
+#### Scenario: Stale promise after stop and re-request does not replace newer media
+- **WHEN** an in-flight user media request is stopped, a newer request is started, the newer request resolves first, and then the older request resolves
+- **THEN** ready state MUST keep the newer stream
+- **AND** the older stream's tracks MUST be stopped
+- **AND** the newer stream's tracks MUST remain live
+
+#### Scenario: Stream resolving after unmount is closed
+- **WHEN** `request` is in flight, the component unmounts, and the media promise later resolves
+- **THEN** the resolved stream's tracks MUST be stopped
+- **AND** the unmounted component MUST NOT retain the stream as active media
+
+#### Scenario: In-flight user media ignored after type changes to display
+- **WHEN** `useMedia("user")` has an in-flight request and the `type` prop changes to `"display"`
+- **THEN** state MUST reset to idle without that user stream
+- **AND** when the stale user media promise later resolves, its tracks MUST be stopped
+- **AND** state MUST remain idle (or otherwise not adopt that user stream)
+
+### Requirement: Unmount and type-change cleanup
+Changing `type` or unmounting MUST bump the request generation and close any currently held stream so tracks are not left live.
+
+#### Scenario: Unmount cleanup stops ready user media tracks
+- **WHEN** the hook is ready with an active stream and the component unmounts
+- **THEN** every track on that stream MUST be stopped
+
+#### Scenario: Type change closes held media and resets state
+- **WHEN** `type` changes while the hook holds media or has an in-flight request
+- **THEN** the hook MUST close any held stream, clear error/loading/media, and return to idle for the new type
+
+### Requirement: closeMedia stops all tracks
+`closeMedia` MUST accept `MediaStream | undefined`. When given a stream, it MUST call `stop()` on every track from `getTracks()`. When given `undefined`, it MUST return without throwing.
+
+#### Scenario: closeMedia stops every track on the stream
+- **WHEN** `closeMedia` is called with a stream that has multiple tracks
+- **THEN** each track's `stop` MUST be invoked once
+
+#### Scenario: closeMedia accepts undefined without throwing
+- **WHEN** `closeMedia(undefined)` is called
+- **THEN** it MUST NOT throw
+
+### Requirement: getSupportedConstraints safe default
+`getSupportedConstraints` MUST return `navigator.mediaDevices.getSupportedConstraints()` when available, otherwise an empty object. It MUST NOT throw when `navigator` or `mediaDevices` is missing.
+
+#### Scenario: Missing mediaDevices returns empty object
+- **WHEN** `navigator.mediaDevices` is undefined
+- **THEN** `getSupportedConstraints()` MUST return `{}`
+
+#### Scenario: Missing navigator returns empty object
+- **WHEN** `globalThis.navigator` is unavailable
+- **THEN** `getSupportedConstraints()` MUST return `{}`

--- a/openspec/changes/baseline-media-capture/tasks.md
+++ b/openspec/changes/baseline-media-capture/tasks.md
@@ -1,0 +1,22 @@
+## 1. Spec–test coverage audit
+
+- [x] 1.1 Map each `media-capture` scenario in `specs/media-capture/spec.md` to a test in `use-media.spec.tsx` or `close-media.spec.ts` (note any scenario without a direct test)
+- [x] 1.2 Confirm user vs display acquisition scenarios match `getUserMedia` / `getDisplayMedia` spies and args
+- [x] 1.3 Confirm state transition scenarios (idle, loading→ready, error, stop→idle) match existing assertions
+- [x] 1.4 Confirm lifecycle scenarios (re-request close, stale after stop/re-request, unmount ready, unmount in-flight, type change) match generation/cleanup tests
+- [x] 1.5 Confirm `closeMedia` and `getSupportedConstraints` scenarios match `close-media.spec.ts`
+
+## 2. Gap documentation
+
+- [x] 2.1 Record uncovered scenarios (if any) as follow-up test candidates without changing production code in this baseline — gaps: (a) no dedicated initial-idle assert before `request`; (b) no explicit happy-path loading→ready sequence assert; (c) no `getUserMedia` `toHaveBeenCalledWith(constraints)` assert (display has args assert); (d) no async `getUserMedia` rejection path (sync throw only); (e) no missing-`getDisplayMedia` capability test; (f) type-change covers in-flight only, not ready-held media
+- [x] 2.2 Confirm proposal Non-goals still hold (no API/behavior changes implied by tasks)
+
+## 3. Optional main-spec sync
+
+- [x] 3.1 Decide whether to sync `media-capture` into `openspec/specs/` via archive/sync workflow (deferred — keep as change delta)
+- [x] 3.2 If syncing, run the project’s OpenSpec sync/archive path so main specs mirror this baseline unchanged (deferred — keep as change delta)
+
+## 4. Validation
+
+- [x] 4.1 Run `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec validate baseline-media-capture --json` and fix artifact issues until valid
+- [x] 4.2 Run package tests for media capture (`use-media.spec.tsx`, `close-media.spec.ts`) to confirm baseline still matches green tests

--- a/openspec/changes/baseline-media-devices/.openspec.yaml
+++ b/openspec/changes/baseline-media-devices/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/baseline-media-devices/design.md
+++ b/openspec/changes/baseline-media-devices/design.md
@@ -1,0 +1,89 @@
+## Context
+
+`@bengreenier/react-user-media` already implements device enumeration as React hooks over `navigator.mediaDevices.enumerateDevices`. This design records the as-built architecture for the `media-devices` capability so future OpenSpec deltas can change behavior against a known baseline. No runtime changes are introduced by this change.
+
+Primary sources:
+
+- `packages/react-user-media/src/hooks/use-media-devices.ts` — `useMediaDevices`, `MediaDeviceState`, `UseMediaDeviceOptions`
+- `packages/react-user-media/src/hooks/use-media-devices-ext.ts` — kind-filtered wrappers
+- `packages/react-user-media/src/hooks/use-media-devices.spec.tsx` — behavioral contract
+- Public re-exports via `packages/react-user-media/src/hooks/index.ts` and package entry
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Document the request-driven state machine (idle / loading / ready / error)
+- Capture filtering, `devicechange` subscription, and stale-request invalidation as designed
+- Describe how extension hooks compose filters without owning separate enumeration logic
+
+**Non-Goals:**
+
+- Changing hook APIs, defaults, or implementation
+- Specifying capture (`useMedia`), tracks, players, or MediaRecorder
+- Adding permission prompts, device selection UI, or label-enrichment strategies beyond what the browser returns from `enumerateDevices`
+
+## Decisions
+
+### 1. Explicit `request()`; no mount-time enumeration
+
+**Choice:** Start idle; enumeration only when `request()` runs (or when `devicechange` fires and monitoring is enabled).
+
+**Rationale:** Enumeration can be gated by secure context and permission state; auto-calling on mount would surprise callers and complicate SSR / unavailable `mediaDevices` cases. Tests assert idle-on-mount and no throw when `mediaDevices` is missing until `request()`.
+
+**Alternatives considered:** Auto-enumerate on mount (rejected for control and testability).
+
+### 2. Discriminated-style flags with shared shape
+
+**Choice:** Expose `isLoading` / `isError` / `isReady`, `error`, `devices`, and `request` as a TypeScript union (`MediaDeviceState`) while returning a single object cast from a shallow shape.
+
+**Rationale:** Matches library convention for other media hooks; consumers can narrow on flags. Runtime avoids exhaustive branch checks for cost.
+
+**Alternatives considered:** Separate return tuples or status enum string (not used elsewhere in this package).
+
+### 3. Filter applied at settle time via ref
+
+**Choice:** Store `filter` in a ref updated each render; apply `devices.filter(filterRef.current)` when the promise succeeds. Default filter is `() => true`.
+
+**Rationale:** `request` is stable (`useCallback` with `[]`); using a ref keeps the latest filter without recreating `request` or ignoring mid-flight option changes. Filter throws are caught and surfaced as error state so loading cannot stick.
+
+**Alternatives considered:** Close over filter in `request` (would freeze filter at call time; tests require latest filter).
+
+### 4. `deviceChangedEvent` defaults to true
+
+**Choice:** Subscribe to `devicechange` when enabled and call `request()`; tear down the listener on option change / unmount. Default `true`.
+
+**Rationale:** Device lists go stale when hardware is plugged/unplugged; opt-out exists for tests and callers who manage refresh themselves.
+
+**Alternatives considered:** Default false (would require every consumer to opt in for live updates).
+
+### 5. Request generation counter for concurrency and unmount
+
+**Choice:** Increment a generation on each `request()` and on unmount teardown; ignore success/error callbacks whose generation no longer matches.
+
+**Rationale:** Overlapping enumerate calls and post-unmount resolutions must not clobber newer UI state or update unmounted trees.
+
+**Alternatives considered:** AbortController (not available on `enumerateDevices` itself); ignore only on unmount (insufficient for overlapping requests).
+
+### 6. Kind filters as thin wrappers
+
+**Choice:** Extension hooks call `useMediaDevices` with a composed filter: kind predicate AND optional caller `filter`.
+
+**Rationale:** Single enumeration implementation; kind helpers stay small and share lifecycle / options behavior. Audio/video use `kind.startsWith(...)`; input/output use exact `kind` equality.
+
+**Alternatives considered:** Separate hooks with duplicated enumerate logic (rejected).
+
+## Risks / Trade-offs
+
+- **[Risk] Labels empty without prior permission** → Mitigation: documented browser behavior; out of scope for this baseline to fabricate labels.
+- **[Risk] `devicechange` only in secure contexts** → Mitigation: listener gated on `addEventListener`; missing API simply skips monitoring.
+- **[Risk] Filter side effects on every settle** → Mitigation: filter is expected to be pure; throws become error state.
+- **[Trade-off] State returned via cast, not runtime narrowing** → Callers rely on TypeScript; incorrect flag combinations are not runtime-validated.
+
+## Migration Plan
+
+Not applicable — documentation-only baseline. Optional later step: archive/sync into `openspec/specs/media-devices/` after review.
+
+## Open Questions
+
+- None for as-built documentation. Future deltas may decide whether to auto-request, expose permission-aware label refresh, or unify state helpers across hooks.

--- a/openspec/changes/baseline-media-devices/proposal.md
+++ b/openspec/changes/baseline-media-devices/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The library already ships `useMediaDevices` and kind-filtered extensions for `enumerateDevices`, but there is no OpenSpec baseline for that behavior. Documenting it as-built gives future deltas a stable contract for request lifecycle, filtering, and `devicechange` handling without changing runtime behavior.
+
+## What Changes
+
+- Add an OpenSpec capability `media-devices` that records existing requirements for:
+  - `useMediaDevices` with idle → loading → ready | error state, `devices`, and `request()`
+  - Options `filter` and `deviceChangedEvent` (default `true`); no auto-request on mount
+  - Kind-filtered extensions: `useMediaAudioDevices`, `useMediaAudioInputDevices`, `useMediaAudioOutputDevices`, `useMediaVideoDevices`
+  - Request generations, filter exceptions, and unmount invalidation
+- No application code, API, or test behavior changes.
+
+## Non-goals
+
+- Implementing or refactoring hooks, extensions, or examples
+- Changing public API signatures or state shape
+- Covering `useMedia`, MediaRecorder, players, or track helpers
+- Expanding browser support beyond what already exists
+- Syncing into `openspec/specs/` as part of this change (optional follow-up)
+
+## Capabilities
+
+### New Capabilities
+
+- `media-devices`: React hooks for enumerating media devices via `navigator.mediaDevices.enumerateDevices`, including optional filtering, `devicechange` re-request, and kind-scoped convenience hooks.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- Planning only: artifacts under `openspec/changes/baseline-media-devices/`
+- Documents existing code in `packages/react-user-media` (`use-media-devices.ts`, `use-media-devices-ext.ts`, package exports) and tests (`use-media-devices.spec.tsx`)
+- No package publish or dependency impact

--- a/openspec/changes/baseline-media-devices/specs/media-devices/spec.md
+++ b/openspec/changes/baseline-media-devices/specs/media-devices/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Explicit request lifecycle with idle default
+`useMediaDevices` MUST start in an idle state and MUST NOT call `enumerateDevices` on mount. Callers MUST obtain devices only by invoking `request()`.
+
+#### Scenario: Idle before any request
+- **WHEN** a component mounts `useMediaDevices` without calling `request()`
+- **THEN** the hook returns `isLoading: false`, `isError: false`, `isReady: false`, `error: null`, and `devices: undefined`
+
+#### Scenario: Mount is safe when mediaDevices is missing
+- **WHEN** `navigator.mediaDevices` is unavailable and the hook mounts with default options
+- **THEN** rendering MUST NOT throw and the hook MUST remain idle
+
+### Requirement: Enumerate devices on request
+Calling `request()` MUST transition through loading and then ready or error based on `navigator.mediaDevices.enumerateDevices`.
+
+#### Scenario: Successful enumeration
+- **WHEN** the caller invokes `request()` and `enumerateDevices` resolves with one or more `MediaDeviceInfo` values
+- **THEN** the hook MUST set `isReady: true`, `isLoading: false`, `isError: false`, `error: null`, and `devices` to the (filtered) result list
+
+#### Scenario: Loading clears prior devices
+- **WHEN** the caller invokes `request()` while `enumerateDevices` is available
+- **THEN** the hook MUST set `isLoading: true`, clear `devices` to `undefined`, and clear `error` to `null` before the promise settles
+
+#### Scenario: Enumerate failure
+- **WHEN** `enumerateDevices` rejects with an error
+- **THEN** the hook MUST set `isError: true`, `isLoading: false`, `isReady: false`, `devices: undefined`, and `error` to that error (or a wrapped `Error`)
+
+#### Scenario: enumerateDevices unavailable
+- **WHEN** the caller invokes `request()` and `navigator.mediaDevices` or `enumerateDevices` is unavailable
+- **THEN** the hook MUST set `isError: true`, `isLoading: false`, `isReady: false`, `devices: undefined`, and `error` with message `enumerateDevices is not available. Are you in a secure context?`
+
+### Requirement: Optional device filter
+`UseMediaDeviceOptions.filter` MUST limit which devices appear in the ready `devices` array. The default filter MUST include all devices. The filter in effect when a pending request resolves MUST be applied (latest filter via ref).
+
+#### Scenario: Filter throws
+- **WHEN** `enumerateDevices` resolves and the configured `filter` throws
+- **THEN** the hook MUST set `isError: true`, `isLoading: false`, `devices: undefined`, and surface the thrown error (not remain loading)
+
+#### Scenario: Latest filter applies to pending request
+- **WHEN** `request()` is in flight and the caller changes `filter` before the promise resolves
+- **THEN** the ready `devices` list MUST reflect the latest filter, not the filter from request start
+
+### Requirement: devicechange monitoring
+When `deviceChangedEvent` is `true` (the default), the hook MUST listen for `navigator.mediaDevices` `devicechange` and re-invoke `request()`. When `deviceChangedEvent` is `false`, the hook MUST NOT re-request on `devicechange`.
+
+#### Scenario: Re-request on devicechange
+- **WHEN** `deviceChangedEvent` is `true` and a `devicechange` event fires after a successful request
+- **THEN** the hook MUST call `enumerateDevices` again and update `devices` with the new result
+
+#### Scenario: Opt out of devicechange
+- **WHEN** `deviceChangedEvent` is `false` and a `devicechange` event fires
+- **THEN** the hook MUST NOT call `enumerateDevices` again solely because of that event
+
+### Requirement: Ignore stale async results
+Concurrent or superseded `enumerateDevices` outcomes MUST NOT overwrite newer state. Unmount MUST invalidate in-flight requests.
+
+#### Scenario: Newer request wins over stale success
+- **WHEN** two `request()` calls overlap and the older promise resolves after the newer one has already produced ready state
+- **THEN** the hook MUST keep the newer ready result and MUST NOT replace it with the stale device list
+
+#### Scenario: Newer request wins over stale rejection
+- **WHEN** two `request()` calls overlap, the newer request succeeds, and the older promise later rejects
+- **THEN** the hook MUST remain ready with the newer devices and MUST NOT transition to error from the stale rejection
+
+#### Scenario: Results after unmount are ignored
+- **WHEN** the component unmounts while `enumerateDevices` is pending and the promise later resolves
+- **THEN** the hook MUST NOT apply that result to React state (no post-unmount update from that generation)
+
+### Requirement: Kind-filtered extension hooks
+The package MUST export convenience hooks that wrap `useMediaDevices` with kind filters, still accepting `UseMediaDeviceOptions` and composing with a caller `filter` when provided.
+
+#### Scenario: Audio and video kind prefixes
+- **WHEN** `useMediaAudioDevices` and `useMediaVideoDevices` request devices from a mixed list
+- **THEN** audio MUST include devices whose `kind` starts with `audio`, and video MUST include devices whose `kind` starts with `video`
+
+#### Scenario: Audio input and output exact kinds
+- **WHEN** `useMediaAudioInputDevices` and `useMediaAudioOutputDevices` request devices from a mixed list
+- **THEN** input MUST include only `kind === "audioinput"` and output MUST include only `kind === "audiooutput"`

--- a/openspec/changes/baseline-media-devices/tasks.md
+++ b/openspec/changes/baseline-media-devices/tasks.md
@@ -1,0 +1,16 @@
+## 1. Spec coverage verification
+
+- [x] 1.1 Confirm `useMediaDevices` idle-on-mount and no auto-request match scenarios in `specs/media-devices/spec.md` against `use-media-devices.ts` / `use-media-devices.spec.tsx`
+- [x] 1.2 Confirm loading → ready | error, secure-context error message, and filter (including throw + latest-filter) scenarios match existing tests
+- [x] 1.3 Confirm `deviceChangedEvent` default/opt-out and stale/unmount generation scenarios match existing tests
+- [x] 1.4 Confirm extension hooks (`useMediaAudioDevices`, `useMediaAudioInputDevices`, `useMediaAudioOutputDevices`, `useMediaVideoDevices`) kind filters match spec scenarios
+
+## 2. Regression checks
+
+- [x] 2.1 Run package tests for media devices: `pnpm --filter @bengreenier/react-user-media test -- use-media-devices`
+- [x] 2.2 Confirm public exports of hooks and types remain available from package entry (`hooks/index.ts` / `src/index.ts`) with no source edits required
+
+## 3. OpenSpec hygiene
+
+- [x] 3.1 Run `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec validate --change baseline-media-devices` and resolve any reported issues
+- [x] 3.2 Optionally archive/sync this capability into `openspec/specs/media-devices/` in a follow-up (out of scope for apply of this baseline) (deferred — keep as change delta)

--- a/openspec/changes/baseline-media-players/.openspec.yaml
+++ b/openspec/changes/baseline-media-players/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/baseline-media-players/design.md
+++ b/openspec/changes/baseline-media-players/design.md
@@ -1,0 +1,77 @@
+## Context
+
+This change baselines existing `VideoPlayer` and `AudioPlayer` components in `packages/react-user-media`. Both are thin `forwardRef` wrappers around native `<video>` / `<audio>` that bind a required `media: MediaProvider` to `srcObject`. Behavior is already covered by `VideoPlayer.spec.tsx` and `AudioPlayer.spec.tsx` (Vitest + Playwright browser mode). No runtime changes are planned.
+
+Public surface is re-exported from `packages/react-user-media/src/components/index.tsx` (`VideoPlayer`, `VideoPlayerProps`, `AudioPlayer`, `AudioPlayerProps`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Record as-built architecture for attaching, updating, and clearing `srcObject`
+- Align design decisions with tested lifecycle (unmount, element replace, media prop change)
+- Give future deltas a stable reference for player prop contracts and ref behavior
+
+**Non-Goals:**
+
+- Changing component APIs or implementation
+- Building custom controls, chrome, or playback state machines
+- Owning stream lifecycle (callers / `useMedia` remain responsible for obtain/release)
+- Expanding to non-`MediaProvider` sources (URL `src` remains intentionally unsupported)
+
+## Decisions
+
+### 1. `srcObject` only — omit `src` / `srcObject` from props
+
+**Choice:** `VideoPlayerProps` / `AudioPlayerProps` extend native element props via `Omit<..., "src" | "srcObject">` and require `media: MediaProvider`.
+
+**Rationale:** Stream playback is the library's domain; allowing `src` would dual-path the element and fight `srcObject` assignment. `MediaProvider` covers `MediaStream` and related providers.
+
+**Alternatives considered:** Accept `src` string for file/URL playback — rejected for this baseline; out of library focus.
+
+### 2. Callback ref owns attach / detach
+
+**Choice:** A `useCallback` ref (`setRef`) forwards to the consumer ref, tracks the current element in an internal ref, sets `element.srcObject = media` on attach, and sets `srcObject = null` when the element becomes `null` or is replaced.
+
+**Rationale:** Attach/clear happens at the DOM host boundary (including unmount), without a separate `useEffect` for cleanup. Replacing the host element clears the previous node before binding the new one.
+
+**Alternatives considered:** `useEffect` + `useImperativeHandle` only — would miss some replace timing; current pattern matches existing tests that invoke the host ref callback directly.
+
+### 3. `media` in the ref callback dependency list
+
+**Choice:** `setRef` depends on `[ref, media]`, so a `media` prop change produces a new callback and React re-invokes it, updating `srcObject` on the same element.
+
+**Rationale:** Keeps assignment logic in one place (the ref callback) rather than splitting mount vs update paths.
+
+**Alternatives considered:** Explicit `useEffect` on `media` — equivalent outcome; not how the shipped code works.
+
+### 4. Symmetric video and audio implementations
+
+**Choice:** `VideoPlayer` and `AudioPlayer` share the same control flow; only the element type (`video` vs `audio`) and attribute types differ.
+
+**Rationale:** Identical lifecycle requirements; duplication is small and keeps types precise (`HTMLVideoElement` vs `HTMLAudioElement`).
+
+**Alternatives considered:** Shared factory/HOC — not present on main; baseline documents current duplication.
+
+### 5. No ownership of stream stop/close
+
+**Choice:** Clearing `srcObject` detaches the element from the provider; it does not call `track.stop()` or `closeMedia`.
+
+**Rationale:** Players are presentation adapters. Capture lifecycle belongs to `useMedia` / callers.
+
+## Risks / Trade-offs
+
+- **[Risk] Ref-callback dependency on React re-invoking when `media` changes** → Mitigation: covered by "updates srcObject when the media prop changes" tests; future React ref semantics changes would need re-validation.
+- **[Risk] Element-replace tests reach into React fiber via `getHostRefCallback`** → Mitigation: test-only helper; production API is ordinary `forwardRef`. Document as test harness detail, not public contract.
+- **[Trade-off] No `src` URL support** → Consumers needing file URLs use a plain `<video>` / `<audio>` or fork; library stays stream-focused.
+- **[Trade-off] Duplicate video/audio modules** → Slight maintenance cost vs shared abstraction; acceptable at current size.
+
+## Migration Plan
+
+Not applicable — documentation-only baseline. No deploy, rollback, or consumer migration.
+
+Optional follow-up: archive/sync delta into `openspec/specs/media-players/` after review.
+
+## Open Questions
+
+- None for baseline accuracy. Future deltas may ask whether to factor a shared internal player helper or add optional URL `src` support; both are out of scope here.

--- a/openspec/changes/baseline-media-players/proposal.md
+++ b/openspec/changes/baseline-media-players/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The library already ships `VideoPlayer` and `AudioPlayer` for binding a `MediaProvider` to `<video>` / `<audio>`, but there is no OpenSpec baseline for that behavior. Documenting it as-built gives future deltas a stable contract for ref forwarding, `srcObject` lifecycle, and prop surface without changing runtime behavior.
+
+## What Changes
+
+- Add an OpenSpec capability `media-players` that records existing requirements for:
+  - `VideoPlayer` / `AudioPlayer` as `forwardRef` wrappers around native media elements
+  - Required `media: MediaProvider`; sets `srcObject`; omits consumer `src` / `srcObject`
+  - Clears `srcObject` on unmount, element replace, and `media` prop change
+  - Forwards remaining HTML media attributes to the underlying element
+- No application code, API, or test behavior changes.
+
+## Non-goals
+
+- Implementing or refactoring player components or test utilities
+- Changing public API signatures or prop types
+- Adding controls UI, play/pause orchestration, or custom media chrome
+- Covering `useMedia`, devices, or MediaRecorder (separate baselines)
+- Syncing into `openspec/specs/` as part of this change (optional follow-up)
+
+## Capabilities
+
+### New Capabilities
+
+- `media-players`: React components that bind a `MediaProvider` to native `<video>` and `<audio>` elements with correct `srcObject` lifecycle and attribute forwarding.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- Planning only: artifacts under `openspec/changes/baseline-media-players/`
+- Documents existing code in `packages/react-user-media` (`VideoPlayer.tsx`, `AudioPlayer.tsx`, `components/index.tsx`) and tests (`VideoPlayer.spec.tsx`, `AudioPlayer.spec.tsx`)
+- No package publish or dependency impact

--- a/openspec/changes/baseline-media-players/specs/media-players/spec.md
+++ b/openspec/changes/baseline-media-players/specs/media-players/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: VideoPlayer binds MediaProvider to a video element
+`VideoPlayer` SHALL render an `HTMLVideoElement`, accept a required `media: MediaProvider` prop, and assign that value to the element's `srcObject`. `VideoPlayerProps` SHALL extend video element attributes while omitting `src` and `srcObject`. The component SHALL be a `forwardRef` wrapper that exposes the underlying video element.
+
+#### Scenario: Plays back user media video
+- **WHEN** `useMedia("user")` becomes ready with a video stream and `VideoPlayer` is rendered with that `media` and `autoPlay`
+- **THEN** the video element SHALL report playback (`played.length` greater than zero)
+
+#### Scenario: Assigns media to srcObject on mount
+- **WHEN** `VideoPlayer` mounts with a `MediaStream` as `media`
+- **THEN** the rendered `<video>` element's `srcObject` SHALL be that stream
+
+### Requirement: AudioPlayer binds MediaProvider to an audio element
+`AudioPlayer` SHALL render an `HTMLAudioElement`, accept a required `media: MediaProvider` prop, and assign that value to the element's `srcObject`. `AudioPlayerProps` SHALL extend audio element attributes while omitting `src` and `srcObject`. The component SHALL be a `forwardRef` wrapper that exposes the underlying audio element.
+
+#### Scenario: Plays back user media audio
+- **WHEN** `useMedia("user")` becomes ready with an audio stream and `AudioPlayer` is rendered with that `media` and `autoPlay`
+- **THEN** the audio element SHALL report playback (`played.length` greater than zero)
+
+#### Scenario: Assigns media to srcObject on mount
+- **WHEN** `AudioPlayer` mounts with a `MediaStream` as `media`
+- **THEN** the rendered `<audio>` element's `srcObject` SHALL be that stream
+
+### Requirement: Players clear srcObject on unmount
+When a player unmounts, it SHALL set the previously attached media element's `srcObject` to `null`.
+
+#### Scenario: VideoPlayer clears srcObject on unmount
+- **WHEN** `VideoPlayer` has attached a stream to a video element and the component unmounts
+- **THEN** that video element's `srcObject` SHALL be `null`
+
+#### Scenario: AudioPlayer clears srcObject on unmount
+- **WHEN** `AudioPlayer` has attached a stream to an audio element and the component unmounts
+- **THEN** that audio element's `srcObject` SHALL be `null`
+
+### Requirement: Players clear srcObject when the DOM element is replaced
+When the host ref callback receives a different media element than the one currently tracked, the player SHALL set the previous element's `srcObject` to `null` and assign `media` to the new element's `srcObject`.
+
+#### Scenario: VideoPlayer clears previous element on replace
+- **WHEN** `VideoPlayer`'s ref callback is invoked with a new `HTMLVideoElement` while a previous video element still holds the stream
+- **THEN** the previous element's `srcObject` SHALL be `null` and the new element's `srcObject` SHALL be the current `media`
+
+#### Scenario: AudioPlayer clears previous element on replace
+- **WHEN** `AudioPlayer`'s ref callback is invoked with a new `HTMLAudioElement` while a previous audio element still holds the stream
+- **THEN** the previous element's `srcObject` SHALL be `null` and the new element's `srcObject` SHALL be the current `media`
+
+### Requirement: Players update srcObject when media changes
+When the `media` prop changes, the player SHALL assign the new `MediaProvider` to the current element's `srcObject`.
+
+#### Scenario: VideoPlayer updates srcObject on media prop change
+- **WHEN** `VideoPlayer` is re-rendered with a different `media` value
+- **THEN** the video element's `srcObject` SHALL equal the new `media`
+
+#### Scenario: AudioPlayer updates srcObject on media prop change
+- **WHEN** `AudioPlayer` is re-rendered with a different `media` value
+- **THEN** the audio element's `srcObject` SHALL equal the new `media`
+
+### Requirement: Players forward non-media-source attributes
+Players SHALL forward remaining HTML media attributes (and other allowed props) to the underlying element, and MUST NOT accept consumer-supplied `src` or `srcObject` (those are omitted from the public props type and driven only via `media`).
+
+#### Scenario: VideoPlayer forwards attributes
+- **WHEN** `VideoPlayer` is rendered with attributes such as `autoPlay` or `data-testid`
+- **THEN** those attributes SHALL be present on the rendered `<video>` element
+
+#### Scenario: AudioPlayer forwards attributes
+- **WHEN** `AudioPlayer` is rendered with attributes such as `autoPlay` or `data-testid`
+- **THEN** those attributes SHALL be present on the rendered `<audio>` element

--- a/openspec/changes/baseline-media-players/tasks.md
+++ b/openspec/changes/baseline-media-players/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spec alignment review
+
+- [x] 1.1 Confirm `VideoPlayer` / `VideoPlayerProps` in `VideoPlayer.tsx` match spec (forwardRef, required `media`, omit `src`/`srcObject`, `<video>` host)
+- [x] 1.2 Confirm `AudioPlayer` / `AudioPlayerProps` in `AudioPlayer.tsx` match spec (forwardRef, required `media`, omit `src`/`srcObject`, `<audio>` host)
+- [x] 1.3 Confirm public re-exports in `components/index.tsx` expose both players and prop types
+
+## 2. Existing test verification
+
+- [x] 2.1 Run `VideoPlayer.spec.tsx` and confirm playback, unmount clear, element-replace clear, and media-prop update scenarios pass
+- [x] 2.2 Run `AudioPlayer.spec.tsx` and confirm playback, unmount clear, element-replace clear, and media-prop update scenarios pass
+- [x] 2.3 Map each ADDED scenario in `specs/media-players/spec.md` to an existing assertion (or note any coverage gap without changing code)
+
+## 3. Baseline closure
+
+- [x] 3.1 Re-read proposal Non-goals and confirm no application source changes were introduced by this change
+- [x] 3.2 Run `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec validate baseline-media-players` and resolve any artifact issues
+- [x] 3.3 Optionally sync/archive into `openspec/specs/media-players/` in a follow-up (out of scope unless requested) (deferred — keep as change delta)

--- a/openspec/changes/baseline-media-recorder/.openspec.yaml
+++ b/openspec/changes/baseline-media-recorder/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/baseline-media-recorder/design.md
+++ b/openspec/changes/baseline-media-recorder/design.md
@@ -1,0 +1,77 @@
+## Context
+
+`@bengreenier/react-user-media` already exports `useMediaRecorder`, `RecorderOptions`, and `RecorderState` from `packages/react-user-media/src/hooks/use-media-recorder.ts`. This change baselines that as-built design for OpenSpec; no runtime changes are intended.
+
+The hook wraps the browser `MediaRecorder` API behind a discriminated React state surface (idle / recording / paused / finalized / error) with explicit start/stop/pause/resume actions. It does not obtain or own the `MediaStream` lifecycle—that belongs to media-capture (`useMedia` / `closeMedia`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Document the current architecture: session id invalidation, recorder cleanup refs, external-store state observation, and error observation
+- Align design narrative with `use-media-recorder.spec.tsx` and public types
+- Give future deltas a stable place to record intentional changes
+
+**Non-Goals:**
+
+- Redesigning the hook, exposing internal helpers, or adding WebCodecs/workers
+- Changing public API or test behavior as part of this baseline
+- Owning stream acquisition or track mute (other capabilities)
+
+## Decisions
+
+### Discriminated `RecorderState` union
+
+**Choice:** Public return type is a union of idle, recording, paused, finalized, and error shapes with boolean flags (`isError`, `isRecording`, `isPaused`, `isFinalized`) plus times and `segments`.
+
+**Rationale:** Matches the library convention of typed lifecycle states; consumers can narrow on flags. Runtime returns a single object cast to the union (`satisfies ShallowShapeOf<RecorderState>`) to avoid per-render checks.
+
+**Alternatives considered:** A single `status: "idle" | ...` enum string—more compact but not how the shipped API works.
+
+### Session id for stale-event isolation
+
+**Choice:** `sessionIdRef` increments on every cleanup (restart and unmount). `dataavailable` handlers, segment `callback`s, stop completion, and error observers compare against the session id captured at subscription/start.
+
+**Rationale:** Restarts and async custom handlers can deliver late events; without session gating, old blobs/errors corrupt the new session (covered by lifecycle tests).
+
+**Alternatives considered:** Relying only on removing listeners—insufficient when custom handlers defer `callback` after restart.
+
+### Internal observation hooks
+
+**Choice:** `useMediaRecorderState` uses `useSyncExternalStore` on `start`/`stop`/`pause`/`resume` to mirror `MediaRecorder.state`. `useMediaRecorderError` listens for `error` events and stores `{ error, sessionId }`. Both are module-private (not exported).
+
+**Rationale:** Keeps public API to `useMediaRecorder` while syncing browser events into React; session-tagged errors avoid late previous-session errors after restart.
+
+### Options: `timeslice` + `dataAvailableHandler`
+
+**Choice:** `RecorderOptions` extends `MediaRecorderOptions` with optional `timeslice` (passed to `start`) and optional `dataAvailableHandler(ev, callback)`. Default handler concatenates `ev.data` onto `segments`.
+
+**Rationale:** Covers common chunked recording and advanced consumers without forking the MediaRecorder options surface.
+
+### Cleanup ownership
+
+**Choice:** `cleanupCurrentRecorder` bumps session id, removes `dataavailable` listener, and `stop()`s if not inactive. Invoked before each `startRecording` and on unmount via `useEffect` cleanup. `stopRecording` itself waits for the `stop` event (once, session-gated) before setting `endTime` / finalized.
+
+**Rationale:** Prevents leaked recorders and ensures finalized timing follows the browser stop lifecycle; empty segment lists still finalize.
+
+### Error paths on construct/start
+
+**Choice:** Synchronous try/catch around `new MediaRecorder` and `recorder.start`; on failure set error state, clear times/segments, and leave no active recorder ref. Event-path errors use the recorder's `error` event (preferring `event.error` when it is an `Error`).
+
+**Rationale:** Construction/start failures must not throw into React event handlers; tests assert they surface as `isError` instead.
+
+## Risks / Trade-offs
+
+- **[Risk] Unmount cleanup is implemented but not directly asserted in unit tests** → Mitigation: verification task to confirm behavior or add a focused test in a future delta
+- **[Risk] `startTime` / `endTime` are part of the public state but lightly exercised in tests (finalized inferred via `endTime`)** → Mitigation: treat timing fields as documented API; optional assertion follow-up
+- **[Risk] Custom `dataAvailableHandler` can still schedule work after unmount if it ignores the gated callback** → Mitigation: session gate on the provided `callback`; document that handlers must use that callback for state updates
+- **[Risk] Hook does not stop tracks or close the stream** → Mitigation: by design; media-capture owns stream lifecycle
+- **[Trade-off] Casting to `RecorderState` skips runtime discriminant validation** → Accepted for performance; TypeScript shapes document the contract
+
+## Migration Plan
+
+Not applicable—documentation-only baseline. Optional follow-up: sync delta into `openspec/specs/media-recorder/` via archive/sync workflow.
+
+## Open Questions
+
+- None for baseline accuracy. Optional product questions (mime-type helpers, automatic blob assembly into a single File) are out of scope until a future change.

--- a/openspec/changes/baseline-media-recorder/proposal.md
+++ b/openspec/changes/baseline-media-recorder/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The library already ships `useMediaRecorder` for wrapping the browser `MediaRecorder` API with React-friendly state and lifecycle controls, but there is no OpenSpec baseline for that behavior. Documenting it as-built gives future deltas a stable contract for recording sessions, pause/resume, segments, and error handling without changing runtime behavior.
+
+## What Changes
+
+- Add an OpenSpec capability `media-recorder` that records existing requirements for:
+  - `useMediaRecorder()` state machine: idle → recording ↔ paused → finalized | error
+  - Actions: `startRecording`, `stopRecording`, `pauseRecording`, `resumeRecording`
+  - Options: `MediaRecorderOptions` plus `timeslice` and `dataAvailableHandler`
+  - Session invalidation on restart/unmount; segment accumulation as `Blob[]`
+- No application code, API, or test behavior changes.
+
+## Non-goals
+
+- Implementing or refactoring the hook or examples
+- Changing public API signatures or discriminated state shape
+- Exposing internal helpers (`useMediaRecorderState`, `useMediaRecorderError`) as public API
+- Adding workers, WebCodecs, or mime-type negotiation beyond current options passthrough
+- Syncing into `openspec/specs/` as part of this change (optional follow-up)
+
+## Capabilities
+
+### New Capabilities
+
+- `media-recorder`: React hook for recording a `MediaStream` via `MediaRecorder`, including pause/resume, segment blobs, session cleanup, and error surfacing.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- Planning only: artifacts under `openspec/changes/baseline-media-recorder/`
+- Documents existing code in `packages/react-user-media` (`use-media-recorder.ts`, public exports) and tests (`use-media-recorder.spec.tsx`)
+- No package publish or dependency impact

--- a/openspec/changes/baseline-media-recorder/specs/media-recorder/spec.md
+++ b/openspec/changes/baseline-media-recorder/specs/media-recorder/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Idle initial state
+`useMediaRecorder` SHALL start in an idle state where `isError`, `isRecording`, `isPaused`, and `isFinalized` are all `false`, `error` is `null`, `startTime` and `endTime` are `null`, and `segments` is an empty array.
+
+#### Scenario: Starts from idle state
+- **WHEN** a component mounts and calls `useMediaRecorder()` without starting
+- **THEN** `isError` is `false`, `isRecording` is `false`, `isFinalized` is `false`, and `segments.length` is `0`
+
+### Requirement: Start recording
+`useMediaRecorder` SHALL expose `startRecording(media, options?)` which creates a `MediaRecorder` for the given `MediaStream`, clears prior segments and end time, records a `startTime`, and transitions to recording (`isRecording` true) when `MediaRecorder.start` succeeds. Optional `RecorderOptions` SHALL extend `MediaRecorderOptions` with `timeslice` and `dataAvailableHandler`. When `timeslice` is omitted, `MediaRecorder.start()` MUST be called with no timeslice argument (browser default). When `timeslice` is provided, `MediaRecorder.start(timeslice)` MUST be used.
+
+#### Scenario: Browser default timeslice
+- **WHEN** the consumer calls `startRecording(media)` without `timeslice`
+- **THEN** the underlying `MediaRecorder.start` is invoked with no arguments
+
+#### Scenario: Explicit timeslice
+- **WHEN** the consumer calls `startRecording(media, { timeslice: 250 })`
+- **THEN** the underlying `MediaRecorder.start` is invoked with `250`
+
+### Requirement: Pause and resume recording
+While recording, `pauseRecording` SHALL pause the active `MediaRecorder` when its state is `"recording"`, setting `isPaused` true and `isRecording` false. `resumeRecording` SHALL resume when state is `"paused"`, restoring `isRecording` true and `isPaused` false. Neither action SHALL finalize the session.
+
+#### Scenario: Pause and resume toggle
+- **WHEN** recording is active and the consumer calls `pauseRecording`
+- **THEN** `isPaused` is `true`, `isRecording` is `false`, and `isFinalized` is `false`
+- **WHEN** the consumer then calls `resumeRecording`
+- **THEN** `isPaused` is `false` and `isRecording` is `true`
+
+### Requirement: Stop and finalize
+`stopRecording` SHALL stop the active `MediaRecorder` when it is not already `"inactive"`. After the recorder's `stop` event for the current session, the hook SHALL set `endTime` and enter the finalized state (`isFinalized` true) with `isRecording` and `isPaused` false. Finalization MUST succeed even when no data segments were produced.
+
+#### Scenario: Finalize with no segments
+- **WHEN** the consumer starts recording and then stops without any `dataavailable` payloads
+- **THEN** `isFinalized` becomes `true` and `segments.length` remains `0`
+
+#### Scenario: Record real user media (integration)
+- **WHEN** the consumer records a live user-media stream via `startRecording` / `stopRecording` with a custom `dataAvailableHandler`
+- **THEN** after stop, `isFinalized` is true and `segments.length` is greater than `0`
+
+### Requirement: Segment accumulation
+By default, each `dataavailable` event for the current session SHALL append `ev.data` to `segments`. A custom `dataAvailableHandler(ev, callback)` MAY replace that behavior; the hook MUST supply a session-gated `callback` that updates `segments` only while the session remains current.
+
+#### Scenario: Default concatenation (implied by restart cleanup)
+- **WHEN** a `dataavailable` event fires for the current session with the default handler
+- **THEN** the event's `Blob` is included in `segments` for that session
+
+### Requirement: Session invalidation on restart
+Calling `startRecording` while a prior session exists SHALL invalidate the previous session: stop the prior recorder if active, remove its `dataavailable` listener, bump the session id, and reset segments. Stale `dataavailable` events and deferred custom-handler callbacks from the previous session MUST NOT mutate `segments`. Late `error` events from the previous recorder MUST NOT set `isError` on the new session.
+
+#### Scenario: Cleans up previous recorder when restarted
+- **WHEN** the consumer starts recording, then starts again
+- **THEN** the first `MediaRecorder` is stopped once
+- **WHEN** the first recorder later dispatches `dataavailable` and the second also dispatches data
+- **THEN** only the current session's data is reflected in `segments` (length `1` for a single new blob)
+
+#### Scenario: Ignores deferred callbacks from previous sessions
+- **WHEN** a custom `dataAvailableHandler` defers its `callback` and the consumer restarts recording before the deferred callback runs
+- **THEN** invoking the deferred callback does not change `segments` (remains `0` after restart reset)
+
+#### Scenario: Ignores late errors from previous sessions
+- **WHEN** the consumer restarts recording and the previous recorder dispatches an `error` in the same turn
+- **THEN** `isError` remains `false` for the new session
+
+### Requirement: Error surfacing
+Constructor failures from `new MediaRecorder`, synchronous failures from `MediaRecorder.start`, and `error` events on the active recorder SHALL set `isError` true, expose `error` with the underlying message when available, and keep `isRecording` false. Native error details (e.g. `DOMException`) MUST be preserved when present on the event. Failed starts MUST NOT leave a recording session active.
+
+#### Scenario: Constructor failure
+- **WHEN** `MediaRecorder` construction throws (e.g. unsupported mimeType)
+- **THEN** `isError` is `true`, `error.message` matches the thrown error, `isRecording` is `false`, and no recorder instance remains active
+
+#### Scenario: start failure
+- **WHEN** `MediaRecorder.start` throws
+- **THEN** `isError` is `true`, `error.message` matches the thrown error, and `isRecording` is `false`
+
+#### Scenario: Native MediaRecorder error event
+- **WHEN** the active recorder dispatches an `error` event carrying a `DOMException`
+- **THEN** `isError` is `true` and `error.message` matches the native error message
+
+#### Scenario: Clears errors when a new recording starts
+- **WHEN** the hook is in an error state from a prior recorder `error` event and the consumer successfully calls `startRecording` again
+- **THEN** `isError` becomes `false`
+
+### Requirement: Unmount cleanup
+On unmount, `useMediaRecorder` SHALL invalidate the current session and stop any non-inactive `MediaRecorder`, preventing further segment updates from that session.
+
+#### Scenario: Cleanup on unmount
+- **WHEN** the component using `useMediaRecorder` unmounts during an active recording
+- **THEN** the active recorder is stopped (if not already inactive) and the session is invalidated

--- a/openspec/changes/baseline-media-recorder/tasks.md
+++ b/openspec/changes/baseline-media-recorder/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec ↔ test audit
+
+- [x] 1.1 Map each scenario in `specs/media-recorder/spec.md` to a case in `use-media-recorder.spec.tsx` (or mark uncovered)
+  - Covered: idle; default/explicit timeslice; pause/resume; finalize empty segments; userMedia integration; restart cleanup (implies default concat); deferred handler invalidation; late error ignore; constructor/`start`/native error; clear error on new start
+  - Uncovered: Cleanup on unmount (see 3.1)
+- [x] 1.2 Confirm public exports (`useMediaRecorder`, `RecorderOptions`, `RecorderState`) match proposal/design; confirm `useMediaRecorderState` / `useMediaRecorderError` remain non-exported
+- [x] 1.3 Confirm state flags and actions in the spec match the discriminated union and callbacks in `use-media-recorder.ts`
+
+## 2. Lifecycle verification
+
+- [x] 2.1 Run `use-media-recorder` Vitest suite (idle, timeslice, pause/resume, finalize empty segments, restart cleanup, deferred handler invalidation, late error ignore) — 12/12 passed
+- [x] 2.2 Run error-path cases (constructor throw, `start` throw, native `error` event, clear error on new start) — included in suite pass
+- [x] 2.3 Run integration case `records userMedia video` (or document environment skip if browser mode unavailable) — passed (343ms)
+
+## 3. Coverage gaps (document only)
+
+- [x] 3.1 Note whether unmount cleanup has a dedicated test; if missing, record as follow-up (do not implement in this baseline) — gap: no dedicated unmount test; impl has `useEffect` → `cleanupCurrentRecorder`; follow-up
+- [x] 3.2 Note whether `startTime` / `endTime` are asserted beyond `isFinalized`; record follow-up if desired — gap: tests assert `isFinalized` only; no direct `startTime`/`endTime` assertions; follow-up
+
+## 4. Optional archive prep
+
+- [x] 4.1 Decide whether to sync this capability into `openspec/specs/media-recorder/` (out of scope unless explicitly requested) (deferred — keep as change delta)
+- [x] 4.2 Validate change with `openspec validate baseline-media-recorder` before archive — valid

--- a/openspec/changes/baseline-media-tracks/.openspec.yaml
+++ b/openspec/changes/baseline-media-tracks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/baseline-media-tracks/design.md
+++ b/openspec/changes/baseline-media-tracks/design.md
@@ -1,0 +1,71 @@
+## Context
+
+As-built documentation of observational track hooks in `@bengreenier/react-user-media`. Implementation lives in `packages/react-user-media/src/hooks/use-media-ext.ts` and is re-exported from `hooks/index.ts`. Coverage is in `use-media-ext.spec.tsx` and `use-track-mute-state.spec.tsx` (Vitest + Playwright browser mode for real `getUserMedia` tracks; mute-state tests use a lightweight `EventTarget` stub).
+
+These hooks complement capture/device hooks: they consume an already-owned `MediaStream` / `MediaStreamTrack` and expose reactive membership and mute state. They do not request permissions or manage stream teardown.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Record the existing observation model: `useSyncExternalStore` + DOM events + cached snapshots
+- Describe kind filtering (`audio` / `video`) and mute-state mapping
+- Clarify that track-list identity is keyed by track `id` sets, not array identity from `getTracks()`
+- Anchor verification to the existing unit/browser tests
+
+**Non-Goals:**
+
+- Changing hook APIs, caching strategy, or event subscriptions
+- Adding enable/disable, ended, or settings observation
+- Owning stream lifecycle or integrating with `useMedia` / recorder / players beyond accepting their streams as inputs
+- Syncing this delta into `openspec/specs/` in this change
+
+## Decisions
+
+### 1. External store over React state for track lists and mute
+
+- **Choice:** `useSyncExternalStore` with subscribe/getSnapshot callbacks closed over `media` / `track`.
+- **Rationale:** Browser media objects are external mutable sources; React docs recommend this for store-like subscriptions and stable `getSnapshot` results.
+- **Alternatives:** `useState` + `useEffect` listeners (more tear/re-render edge cases); polling `getTracks()` (wasteful, less precise).
+
+### 2. Event-driven invalidation, snapshot from live media
+
+- **Choice:** Subscribe to `addtrack`/`removetrack` (stream) or `mute`/`unmute` (track). On notification, `getSnapshot` re-reads `media.getTracks()` (optionally filtered by kind) or `track.muted`.
+- **Rationale:** Matches Web platform events; keeps React in sync when membership or mute changes.
+- **Note (as-tested):** Specs/tests call `addTrack`/`removeTrack` and also dispatch the matching events where the environment may not emit them, so requirements are framed around the subscription + snapshot contract rather than guaranteeing native event emission from every mutation path.
+
+### 3. Snapshot cache keyed by track id set
+
+- **Choice:** Module-level frozen `EMPTY_TRACKS`; per-hook `useRef` cache; update only when `hasSameTrackIds` detects a different set of ids (order-insensitive set equality). Empty results reuse `EMPTY_TRACKS`.
+- **Rationale:** `getTracks()` always returns a new array; caching satisfies `useSyncExternalStore`'s stable-snapshot requirement and preserves references for kind-filtered hooks when unrelated kinds change.
+- **Alternatives:** Always return a fresh array (breaks referential equality consumers); deep-compare track objects (unnecessary for id-keyed membership).
+
+### 4. Kind filters as thin wrappers
+
+- **Choice:** Private `useMediaTracksByKind(media, kind)` shared by `useMediaAudioTracks` / `useMediaVideoTracks`; `useMediaTracks` is a parallel implementation without a filter.
+- **Rationale:** Same subscription and cache rules; filter in `getSnapshot` so audio/video consumers do not re-render when only the other kind's ids change.
+
+### 5. Mute as a two-value string union
+
+- **Choice:** `TrackMuteState = "muted" | "unmuted"` derived from boolean `track.muted`.
+- **Rationale:** Explicit UI-friendly labels; required `MediaStreamTrack` argument (no `undefined` overload), unlike stream hooks which accept `undefined` for optional media.
+
+### 6. No lifecycle ownership
+
+- **Choice:** Hooks never `stop()` tracks or close streams; unsubscribe only removes event listeners.
+- **Rationale:** Observation is composable with any stream source (`useMedia`, peer connections, tests). Lifecycle remains the caller's responsibility.
+
+## Risks / Trade-offs
+
+- **[Risk] Membership changes without `addtrack`/`removetrack` leave React stale** → Mitigation: document event-driven contract; tests dispatch events; callers using non-emitting mutation paths must ensure events fire or remount with a new stream reference.
+- **[Risk] Shared frozen empty array is mutated by a hostile caller** → Mitigation: `Object.freeze`; tests assert `TypeError` on push and isolation across hook instances.
+- **[Trade-off] Id-set equality ignores track property changes** (e.g. `enabled`, `readyState`) → Acceptable for membership hooks; mute has its own hook; other properties are out of scope.
+- **[Trade-off] Duplicate implementation between all-tracks and by-kind paths** → Slight duplication vs shared helper taking optional kind; kept as-built for clarity and independent caches.
+
+## Migration Plan
+
+Not applicable — baseline documentation only; no runtime migration.
+
+## Open Questions
+
+- None for baseline accuracy. Optional follow-up: archive/sync into `openspec/specs/media-tracks/` when the project adopts main specs.

--- a/openspec/changes/baseline-media-tracks/proposal.md
+++ b/openspec/changes/baseline-media-tracks/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The library already ships observational hooks for `MediaStream` track membership and per-track mute state, but there is no OpenSpec baseline for that behavior. Documenting it as-built gives future deltas a stable contract for subscription, snapshot stability, and kind filtering without changing runtime behavior.
+
+## What Changes
+
+- Add an OpenSpec capability `media-tracks` that records existing requirements for:
+  - `useMediaTracks`, `useMediaAudioTracks`, `useMediaVideoTracks`
+  - `useTrackMuteState` and `TrackMuteState`
+  - Observational `useSyncExternalStore` subscriptions (`addtrack`/`removetrack`, `mute`/`unmute`)
+  - Snapshot caching / frozen empty arrays; no stream lifecycle ownership
+- No application code, API, or test behavior changes.
+
+## Non-goals
+
+- Implementing or refactoring hooks, helpers, or examples
+- Changing public API signatures or return types
+- Owning or stopping `MediaStream` / track lifecycle (capture, recorder, players)
+- Adding track enable/disable controls beyond mute observation
+- Syncing into `openspec/specs/` as part of this change (optional follow-up)
+
+## Capabilities
+
+### New Capabilities
+
+- `media-tracks`: React hooks that observe a `MediaStream`'s tracks (optionally by kind) and a track's mute state via external-store subscriptions, without owning media lifecycle.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- Planning only: artifacts under `openspec/changes/baseline-media-tracks/`
+- Documents existing code in `packages/react-user-media` (`hooks/use-media-ext.ts`, re-exported from `hooks/index.ts`) and tests (`use-media-ext.spec.tsx`, `use-track-mute-state.spec.tsx`)
+- No package publish or dependency impact

--- a/openspec/changes/baseline-media-tracks/specs/media-tracks/spec.md
+++ b/openspec/changes/baseline-media-tracks/specs/media-tracks/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Observe all tracks on a MediaStream
+
+`useMediaTracks` SHALL observe the tracks of a caller-provided `MediaStream | undefined` via `useSyncExternalStore`, subscribe to the stream's `addtrack` and `removetrack` events when a stream is present, and return the current `MediaStreamTrack[]` from `MediaStream.getTracks()` with referential stability when the set of track ids is unchanged.
+
+#### Scenario: Tracks update when a track is removed
+
+- **WHEN** a `MediaStream` with audio and video tracks is passed to `useMediaTracks` and a track is removed with a corresponding `removetrack` event
+- **THEN** the hook return value SHALL update to the remaining tracks only
+
+#### Scenario: Tracks update when a track is replaced at the same count
+
+- **WHEN** a stream's only track is removed and a different track of the same kind is added, with corresponding `removetrack` and `addtrack` events
+- **THEN** the hook return value SHALL contain the replacement track (not the original), even though the track count is unchanged
+
+#### Scenario: Undefined media yields a stable empty array
+
+- **WHEN** `useMediaTracks` is called with `undefined`, or the media argument becomes `undefined` after previously observing a stream
+- **THEN** the hook SHALL return an empty array, and repeated snapshots with `undefined` media SHALL be referentially equal
+
+#### Scenario: Empty MediaStream yields a frozen empty array
+
+- **WHEN** `useMediaTracks` is called with a `MediaStream` that has no tracks
+- **THEN** the hook SHALL return a frozen empty array
+
+#### Scenario: Empty snapshot is shared and immutable
+
+- **WHEN** a caller receives an empty track array from `useMediaTracks(undefined)` and attempts to mutate it
+- **THEN** mutation SHALL fail (frozen array) and other hook instances SHALL continue to see an empty array
+
+#### Scenario: Subscription follows the current media argument
+
+- **WHEN** the media argument is replaced with a different `MediaStream` and the previous stream later emits `removetrack`
+- **THEN** the hook SHALL continue reflecting only the current stream's tracks and SHALL ignore events from the previous stream
+
+### Requirement: Observe audio tracks by kind
+
+`useMediaAudioTracks` SHALL observe only tracks whose `kind` is `"audio"` on a caller-provided `MediaStream | undefined`, using the same subscription and snapshot-stability model as all-track observation.
+
+#### Scenario: Audio snapshot stays stable when only video tracks change
+
+- **WHEN** `useMediaAudioTracks` is observing a stream that already has an audio track and a video track is added with an `addtrack` event
+- **THEN** the returned audio track array reference SHALL remain unchanged
+
+### Requirement: Observe video tracks by kind
+
+`useMediaVideoTracks` SHALL observe only tracks whose `kind` is `"video"` on a caller-provided `MediaStream | undefined`, using the same subscription and snapshot-stability model as all-track observation.
+
+#### Scenario: Video snapshot stays stable when only audio tracks change
+
+- **WHEN** `useMediaVideoTracks` is observing a stream that already has a video track and an audio track is added with an `addtrack` event
+- **THEN** the returned video track array reference SHALL remain unchanged
+
+### Requirement: Observe track mute state
+
+`useTrackMuteState` SHALL observe a caller-provided `MediaStreamTrack` via `useSyncExternalStore`, subscribe to the track's `mute` and `unmute` events, and return `TrackMuteState` (`"muted" | "unmuted"`) derived from `track.muted`.
+
+#### Scenario: Initial state matches track.muted
+
+- **WHEN** `useTrackMuteState` is called with a track whose `muted` property is `true`
+- **THEN** the hook SHALL return `"muted"`
+
+#### Scenario: Mute and unmute events update state
+
+- **WHEN** the observed track's `muted` property changes and the corresponding `mute` or `unmute` event is dispatched
+- **THEN** the hook SHALL return `"muted"` or `"unmuted"` accordingly
+
+#### Scenario: Subscription follows the current track argument
+
+- **WHEN** the track argument is replaced with a different track and the previous track later emits `mute`
+- **THEN** the hook SHALL ignore the previous track's event and SHALL update only when the current track emits mute/unmute
+
+### Requirement: Observational ownership only
+
+The media-tracks hooks SHALL NOT create, stop, or otherwise own `MediaStream` or `MediaStreamTrack` lifecycle; callers remain responsible for obtaining and releasing media.
+
+#### Scenario: Hooks accept externally owned media
+
+- **WHEN** a caller passes an existing `MediaStream` or `MediaStreamTrack` into these hooks
+- **THEN** the hooks SHALL only subscribe and read snapshots; they SHALL NOT call `stop()` or release the stream as part of observation

--- a/openspec/changes/baseline-media-tracks/tasks.md
+++ b/openspec/changes/baseline-media-tracks/tasks.md
@@ -1,0 +1,36 @@
+## 1. Spec–test coverage audit
+
+- [x] 1.1 Map each `media-tracks` scenario in `specs/media-tracks/spec.md` to a test in `use-media-ext.spec.tsx` or `use-track-mute-state.spec.tsx` (note any scenario without a direct test)
+  - remove → `updates media tracks when a track is removed`
+  - replace-at-same-count → `updates media tracks when a track is replaced at the same count`
+  - undefined media → `returns a stable empty array when media becomes undefined`
+  - empty stream → `returns a frozen empty array for an empty MediaStream`
+  - frozen empty / shared immutable → `does not poison empty track snapshots when a caller mutates one`
+  - previous-stream events ignored → `ignores track events from a previous media stream after rerender`
+  - audio kind stability → `keeps audio track references stable when only video tracks change`
+  - video kind stability → `keeps video track references stable when only audio tracks change`
+  - initial muted → `useTrackMuteState starts muted when the track is muted`
+  - mute/unmute events → `useTrackMuteState reflects muted and unmute events`
+  - previous-track events ignored → `useTrackMuteState ignores mute events from a previous track`
+  - observational ownership → no dedicated test; confirmed via `use-media-ext.ts` (subscribe/read only)
+- [x] 1.2 Confirm all-track scenarios (remove, replace-at-same-count, undefined media, empty stream, frozen empty, previous-stream events ignored) match `useMediaTracks` tests
+- [x] 1.3 Confirm kind-filter stability scenarios match `useMediaAudioTracks` / `useMediaVideoTracks` tests
+- [x] 1.4 Confirm mute-state scenarios (initial muted, mute/unmute events, previous-track events ignored) match `useTrackMuteState` tests
+- [x] 1.5 Confirm observational-ownership scenario is consistent with implementation (no `stop()` / stream release in `use-media-ext.ts`)
+
+## 2. Gap documentation
+
+- [x] 2.1 Record uncovered scenarios (if any) as follow-up test candidates without changing production code in this baseline
+  - Spec scenarios: none uncovered (all 12 have a direct test or code-inspection confirmation for ownership).
+  - Optional follow-ups (not spec gaps): `useMediaAudioTracks`/`useMediaVideoTracks` with `undefined` media; explicit assertion that hooks never call `track.stop()`.
+- [x] 2.2 Confirm proposal Non-goals still hold (no API/behavior changes implied by tasks)
+
+## 3. Optional main-spec sync
+
+- [x] 3.1 Decide whether to sync `media-tracks` into `openspec/specs/` via archive/sync workflow (deferred — keep as change delta)
+- [x] 3.2 If syncing, run the project’s OpenSpec sync/archive path so main specs mirror this baseline unchanged (deferred — keep as change delta)
+
+## 4. Validation
+
+- [x] 4.1 Run `OPENSPEC_TELEMETRY=0 npx --yes @fission-ai/openspec validate baseline-media-tracks --json` and fix artifact issues until valid
+- [x] 4.2 Run package tests for media tracks (`use-media-ext.spec.tsx`, `use-track-mute-state.spec.tsx`) to confirm baseline still matches green tests


### PR DESCRIPTION
## Summary
- Add five completed OpenSpec baseline changes documenting as-built library behavior: `media-capture`, `media-devices`, `media-tracks`, `media-recorder`, and `media-players`
- Each change includes proposal, design, delta specs, and verification tasks (all marked complete; main-spec sync deferred)
- No application source changes — planning artifacts only under `openspec/changes/`

## Test plan
- [x] `openspec validate --strict` for all five changes
- [x] `pnpm --filter @bengreenier/react-user-media test` — 59/59 passed
- [ ] Confirm PR diff is openspec-only (no `packages/` edits)
- [ ] Optional follow-up: archive/sync baselines into `openspec/specs/`


Made with [Cursor](https://cursor.com)