### PR TITLE
feat(audio): add realtime worklet level meter

### DIFF
--- a/openspec/changes/add-audio-processing-strategies/tasks.md
+++ b/openspec/changes/add-audio-processing-strategies/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Shared foundation
 
-- [ ] 1.1 Define shared public types: `AudioFrame`, `AudioProcessOptions`, `AudioProcessResult`, and strategy/lifecycle unions (audio-namespaced; do not seal a single PCM-only global processor type)
-- [ ] 1.2 Document strategy selection guide in README (worklet vs worker vs worklet-rpc); note video/WebCodecs as future extensions on the worker/Comlink path
-- [ ] 1.3 Add packaging stubs for ESM subpaths and override options (`workletModuleUrl`, `createWorker`)
-- [ ] 1.4 Design-review checkpoint: worker job surface (`configure` / process / `subscribe` / `dispose` + transfer) remains plausible for future `VideoFrame` / WebCodecs jobs without a rewrite
+- [x] 1.1 Define shared public types: `AudioFrame`, `AudioProcessOptions`, `AudioProcessResult`, and strategy/lifecycle unions (audio-namespaced; do not seal a single PCM-only global processor type)
+- [x] 1.2 Document strategy selection guide in README (worklet vs worker vs worklet-rpc); note video/WebCodecs as future extensions on the worker/Comlink path
+- [x] 1.3 Add packaging stubs for ESM subpaths and override options (`workletModuleUrl`, `createWorker`)
+- [x] 1.4 Design-review checkpoint: worker job surface (`configure` / process / `subscribe` / `dispose` + transfer) remains plausible for future `VideoFrame` / WebCodecs jobs without a rewrite
 
 ## 2. Phase 1 — AudioWorklet realtime
 
-- [ ] 2.1 Implement level-meter `AudioWorkletProcessor` with sync `process` and throttled port metrics
-- [ ] 2.2 Build ESM worklet module emit + `addModule` factory
-- [ ] 2.3 Implement stream hook for `strategy: "worklet"` (graph wire-up, context resume, teardown, session ids)
-- [ ] 2.4 Tests: module failure → error; cleanup; tracks not stopped; levels from synthetic/live audio
-- [ ] 2.5 Examples demo: live level meter via worklet
+- [x] 2.1 Implement level-meter `AudioWorkletProcessor` with sync `process` and throttled port metrics
+- [x] 2.2 Build ESM worklet module emit + `addModule` factory
+- [x] 2.3 Implement stream hook for `strategy: "worklet"` (graph wire-up, context resume, teardown, session ids)
+- [x] 2.4 Tests: module failure → error; cleanup; tracks not stopped; levels from synthetic/live audio
+- [x] 2.5 Examples demo: live level meter via worklet
 
 ## 3. Phase 2 — Dedicated Worker + Comlink
 

--- a/packages/examples/src/AudioLevelMeter.tsx
+++ b/packages/examples/src/AudioLevelMeter.tsx
@@ -1,0 +1,33 @@
+import { useMediaAudioProcessor } from "@bengreenier/react-user-media";
+
+const workletModuleUrl = new URL(
+  "../../react-user-media/src/audio-worklet/level-meter.ts",
+  import.meta.url,
+);
+
+export function AudioLevelMeter({ media }: { media: MediaStream }) {
+  const processor = useMediaAudioProcessor({
+    strategy: "worklet",
+    workletModuleUrl,
+  });
+
+  return (
+    <section>
+      <h2>Live audio level</h2>
+      {!processor.isReady && (
+        <button onClick={() => processor.start(media)}>
+          Start level meter
+        </button>
+      )}
+      {processor.isLoading && <p>Starting meter...</p>}
+      {processor.isError && <p>{processor.error.message}</p>}
+      {processor.isReady && (
+        <>
+          <p>RMS: {processor.result?.rms.toFixed(3) ?? "0.000"}</p>
+          <p>Peak: {processor.result?.peak.toFixed(3) ?? "0.000"}</p>
+          <button onClick={processor.stop}>Stop level meter</button>
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/examples/src/WebcamPreview.tsx
+++ b/packages/examples/src/WebcamPreview.tsx
@@ -4,6 +4,7 @@ import {
   useMediaTracks,
   VideoPlayer,
 } from "@bengreenier/react-user-media";
+import { AudioLevelMeter } from "./AudioLevelMeter";
 
 export function WebcamPreview() {
   const { request, isError, error, isLoading, isReady, media } =
@@ -40,6 +41,7 @@ export function WebcamPreview() {
       {isReady && (
         <>
           <VideoPlayer autoPlay media={media} />
+          <AudioLevelMeter media={media} />
           <ul>
             {tracks.map((track) => (
               <li key={track.id}>

--- a/packages/react-user-media/README.md
+++ b/packages/react-user-media/README.md
@@ -25,6 +25,32 @@ A collection of hooks and components for easier access to [`getUserMedia`](https
   - `useMediaVideoDevices()`
 
 - `useMediaRecorder()`
+- `useMediaAudioProcessor({ strategy: "worklet" })`
+
+## Audio processing strategies
+
+Choose the browser primitive that matches the workload:
+
+| Need | Strategy |
+| --- | --- |
+| Live microphone meters, lightweight effects, or VAD-lite | `audio-worklet` |
+| Offline, heavy, or buffer-oriented jobs | `audio-worker` (planned) |
+| Live DSP with an RPC-shaped control plane | `audio-worklet-rpc` (planned) |
+
+The worklet hook receives a caller-owned `MediaStream`; it creates a
+`MediaStreamAudioSourceNode` → `AudioWorkletNode` → silent gain graph and
+never stops the stream's tracks when stopped or unmounted.
+
+`@bengreenier/react-user-media/audio-worklet` provides
+`getLevelMeterWorkletModuleUrl()` and `addLevelMeterWorklet()` for ESM
+consumers. Pass `workletModuleUrl` to `useMediaAudioProcessor` when testing or
+when a bundler needs an explicit URL. The default module-relative URL is not
+guaranteed under CJS `require`.
+
+The worker surface deliberately uses `configure` / process / `subscribe` /
+`dispose` lifecycle conventions and a `createWorker` override so a future
+worker + Comlink implementation can accept transferable `VideoFrame` and
+WebCodecs jobs without replacing the audio APIs.
 
 ## Components
 

--- a/packages/react-user-media/package.json
+++ b/packages/react-user-media/package.json
@@ -8,6 +8,16 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./audio-worklet": {
+      "types": "./dist/types/audio-worklet/index.d.ts",
+      "import": "./dist/audio-worklet/index.js",
+      "require": "./dist/audio-worklet/index.cjs"
+    },
+    "./audio-worker": {
+      "types": "./dist/types/audio-worker/index.d.ts",
+      "import": "./dist/audio-worker/index.js",
+      "require": "./dist/audio-worker/index.cjs"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -28,7 +38,7 @@
     }
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.types.json --emitDeclarationOnly && tsup --tsconfig ./tsconfig.lib.json --format cjs,esm src/index.ts",
+    "build": "tsc -p ./tsconfig.types.json --emitDeclarationOnly && tsup --tsconfig ./tsconfig.lib.json --format cjs,esm src/index.ts src/audio-worklet/index.ts src/audio-worklet/level-meter.ts src/audio-worker/index.ts",
     "doc": "typedoc --plugin typedoc-github-theme --tsconfig ./tsconfig.lib.json --readme ./README.md --basePath ./src --out ./docs_out --entryPoints ./src/index.ts",
     "test": "vitest run --coverage",
     "test-visible": "vitest run --coverage --browser.headless false",

--- a/packages/react-user-media/src/audio-worker/index.ts
+++ b/packages/react-user-media/src/audio-worker/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Reserved worker factory override for the Phase 2 worker strategy.
+ *
+ * The API intentionally accepts a generic module URL rather than assuming PCM
+ * frames, so future WebCodecs `VideoFrame` jobs can share its lifecycle.
+ */
+export interface AudioWorkerModuleOptions {
+  readonly createWorker?: (moduleUrl: string | URL) => Worker;
+}

--- a/packages/react-user-media/src/audio-worklet/index.ts
+++ b/packages/react-user-media/src/audio-worklet/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns the ESM module URL for the built-in level-meter AudioWorklet.
+ *
+ * CJS consumers should provide `workletModuleUrl`, because module-relative
+ * worklet URLs are only guaranteed for ESM consumers.
+ */
+export function getLevelMeterWorkletModuleUrl(): URL {
+  return new URL(/* @vite-ignore */ "./level-meter.js", import.meta.url);
+}
+
+/**
+ * Loads the built-in level-meter processor into an AudioContext.
+ */
+export function addLevelMeterWorklet(
+  audioContext: AudioContext,
+  moduleUrl: string | URL = getLevelMeterWorkletModuleUrl(),
+): Promise<void> {
+  return audioContext.audioWorklet.addModule(moduleUrl);
+}

--- a/packages/react-user-media/src/audio-worklet/level-meter.spec.ts
+++ b/packages/react-user-media/src/audio-worklet/level-meter.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { calculateAudioLevels } from "./levels";
+
+test("calculates mixed RMS and peak from input channels", () => {
+  const result = calculateAudioLevels([
+    [new Float32Array([0, 1, -0.5])],
+    [new Float32Array([0.5, -1])],
+  ]);
+
+  expect(result.rms).toBeCloseTo(Math.sqrt(2.5 / 5));
+  expect(result.peak).toBe(1);
+});
+
+test("reports silent levels when the worklet has no input frames", () => {
+  expect(calculateAudioLevels([])).toEqual({ rms: 0, peak: 0 });
+});

--- a/packages/react-user-media/src/audio-worklet/level-meter.ts
+++ b/packages/react-user-media/src/audio-worklet/level-meter.ts
@@ -1,0 +1,35 @@
+import type { AudioProcessResult } from "../audio";
+import { calculateAudioLevels } from "./levels";
+
+const DEFAULT_METRIC_INTERVAL_SECONDS = 1 / 30;
+
+declare abstract class AudioWorkletProcessor {
+  readonly port: MessagePort;
+}
+
+declare function registerProcessor(
+  name: string,
+  processorCtor: new () => AudioWorkletProcessor,
+): void;
+
+declare const currentTime: number;
+
+class LevelMeterProcessor extends AudioWorkletProcessor {
+  #lastMetricTime = -Infinity;
+
+  process(inputs: Float32Array[][]): boolean {
+    if (currentTime - this.#lastMetricTime >= DEFAULT_METRIC_INTERVAL_SECONDS) {
+      this.#lastMetricTime = currentTime;
+      const levels = calculateAudioLevels(inputs);
+      const result: AudioProcessResult = {
+        ...levels,
+        timestamp: currentTime,
+      };
+      this.port.postMessage(result);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor("react-user-media-level-meter", LevelMeterProcessor);

--- a/packages/react-user-media/src/audio-worklet/levels.ts
+++ b/packages/react-user-media/src/audio-worklet/levels.ts
@@ -1,0 +1,28 @@
+/**
+ * Calculates a mixed RMS and peak value for the input channels in a render
+ * quantum. Keeping this pure also makes synthetic frame testing possible.
+ */
+export function calculateAudioLevels(inputs: readonly Float32Array[][]): {
+  rms: number;
+  peak: number;
+} {
+  let sampleCount = 0;
+  let sumOfSquares = 0;
+  let peak = 0;
+
+  for (const input of inputs) {
+    for (const channel of input) {
+      for (const sample of channel) {
+        const magnitude = Math.abs(sample);
+        sumOfSquares += sample * sample;
+        peak = Math.max(peak, magnitude);
+        sampleCount += 1;
+      }
+    }
+  }
+
+  return {
+    rms: sampleCount === 0 ? 0 : Math.sqrt(sumOfSquares / sampleCount),
+    peak,
+  };
+}

--- a/packages/react-user-media/src/audio.ts
+++ b/packages/react-user-media/src/audio.ts
@@ -1,0 +1,97 @@
+/**
+ * A PCM audio frame for processor strategies that operate on buffered audio.
+ * Future worker strategies can add video/WebCodecs frame types alongside this
+ * audio-specific contract without changing the lifecycle surface.
+ */
+export interface AudioFrame {
+  readonly data: Float32Array;
+  readonly sampleRate: number;
+  readonly timestamp: number;
+  readonly numberOfChannels: number;
+}
+
+/**
+ * Common processing options for audio strategies.
+ */
+export interface AudioProcessOptions {
+  readonly metricIntervalMs?: number;
+}
+
+/**
+ * A summary emitted by an audio processor.
+ */
+export interface AudioProcessResult {
+  readonly rms: number;
+  readonly peak: number;
+  readonly timestamp: number;
+}
+
+/**
+ * Available audio processing strategies. Worker and worklet-rpc are reserved
+ * for additive future phases; this release implements only `worklet`.
+ */
+export type AudioProcessingStrategy = "worklet" | "worker" | "worklet-rpc";
+
+interface AudioProcessorStateBase {
+  readonly isLoading: boolean;
+  readonly isReady: boolean;
+  readonly isError: boolean;
+  readonly error: Error | null;
+  readonly result: AudioProcessResult | null;
+  start(media: MediaStream): void;
+  stop(): void;
+}
+
+export interface AudioProcessorIdleState extends AudioProcessorStateBase {
+  readonly isLoading: false;
+  readonly isReady: false;
+  readonly isError: false;
+  readonly error: null;
+  readonly result: null;
+}
+
+export interface AudioProcessorLoadingState extends AudioProcessorStateBase {
+  readonly isLoading: true;
+  readonly isReady: false;
+  readonly isError: false;
+  readonly error: null;
+  readonly result: null;
+}
+
+export interface AudioProcessorReadyState extends AudioProcessorStateBase {
+  readonly isLoading: false;
+  readonly isReady: true;
+  readonly isError: false;
+  readonly error: null;
+}
+
+export interface AudioProcessorErrorState extends AudioProcessorStateBase {
+  readonly isLoading: false;
+  readonly isReady: false;
+  readonly isError: true;
+  readonly error: Error;
+  readonly result: null;
+}
+
+export type AudioProcessorState =
+  | AudioProcessorIdleState
+  | AudioProcessorLoadingState
+  | AudioProcessorReadyState
+  | AudioProcessorErrorState;
+
+export interface MediaAudioProcessorOptions extends AudioProcessOptions {
+  /**
+   * This phase supports the graph-native AudioWorklet strategy.
+   */
+  readonly strategy: "worklet";
+  /**
+   * An ESM URL passed to `audioWorklet.addModule`. Supply this when a bundler
+   * cannot resolve the package's default ESM worklet module URL.
+   */
+  readonly workletModuleUrl?: string | URL;
+  /**
+   * Creates the owned AudioContext. This injection point supports tests and
+   * applications with specialized browser audio context configuration.
+   */
+  readonly createAudioContext?: () => AudioContext;
+}

--- a/packages/react-user-media/src/hooks/index.ts
+++ b/packages/react-user-media/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./use-media";
+export * from "./use-media-audio-processor";
 export * from "./use-media-devices";
 export * from "./use-media-devices-ext";
 export * from "./use-media-ext";

--- a/packages/react-user-media/src/hooks/use-media-audio-processor.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-audio-processor.spec.tsx
@@ -1,6 +1,8 @@
 import "@testing-library/jest-dom";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@vitest/browser/context";
 import { afterEach, expect, test, vi } from "vitest";
+import levelMeterWorkletUrl from "../audio-worklet/level-meter.ts?url";
 import { useMediaAudioProcessor } from "./use-media-audio-processor";
 
 class MockPort extends EventTarget {
@@ -53,14 +55,16 @@ class MockAudioContext {
 function AudioProcessorHarness({
   media,
   context,
+  workletModuleUrl = "https://example.test/level-meter.js",
 }: {
   media: MediaStream;
-  context: MockAudioContext;
+  context: MockAudioContext | AudioContext;
+  workletModuleUrl?: string;
 }) {
   const processor = useMediaAudioProcessor({
     strategy: "worklet",
     createAudioContext: () => context as unknown as AudioContext,
-    workletModuleUrl: "https://example.test/level-meter.js",
+    workletModuleUrl,
   });
 
   return (
@@ -154,4 +158,79 @@ test("exposes worklet level messages while its session is current", async () => 
   });
 
   expect(screen.getByTestId("rms")).toHaveTextContent("0.25");
+});
+
+test("tears down an active session when unmounted without stopping tracks", async () => {
+  const context = new MockAudioContext();
+  const stop = vi.fn();
+  const media = {
+    getTracks: () => [{ stop }],
+  } as unknown as MediaStream;
+  vi.stubGlobal("AudioWorkletNode", MockNode);
+
+  const view = render(
+    <AudioProcessorHarness context={context} media={media} />,
+  );
+
+  await act(async () => {
+    screen.getByRole("button", { name: "start" }).click();
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("ready");
+  });
+
+  const processor = context.source.connect.mock.calls[0]?.[0] as MockNode;
+  view.unmount();
+
+  expect(context.source.disconnect).toHaveBeenCalledOnce();
+  expect(processor.disconnect).toHaveBeenCalledOnce();
+  expect(context.gain.disconnect).toHaveBeenCalledOnce();
+  expect(processor.port.closed).toBe(true);
+  expect(processor.port.onmessage).toBeNull();
+  expect(context.close).toHaveBeenCalledOnce();
+  expect(stop).not.toHaveBeenCalled();
+});
+
+test("reports non-silent levels from a live synthetic audio graph", async () => {
+  const inputContext = new AudioContext();
+  const processorContext = new AudioContext();
+  const oscillator = inputContext.createOscillator();
+  const destination = inputContext.createMediaStreamDestination();
+  const source = processorContext.createMediaStreamSource(destination.stream);
+  oscillator.frequency.value = 440;
+  oscillator.connect(destination);
+  oscillator.start();
+
+  await processorContext.audioWorklet.addModule(levelMeterWorkletUrl);
+  const processor = new AudioWorkletNode(
+    processorContext,
+    "react-user-media-level-meter",
+  );
+  const silentGain = processorContext.createGain();
+  silentGain.gain.value = 0;
+  source.connect(processor);
+  processor.connect(silentGain);
+  silentGain.connect(processorContext.destination);
+
+  const message = new Promise<{ rms: number; peak: number }>((resolve) => {
+    processor.port.onmessage = (event) => {
+      const levels = event.data as { rms: number; peak: number };
+      if (levels.rms > 0 && levels.peak > 0) {
+        resolve(levels);
+      }
+    };
+  });
+
+  render(<button>Activate audio</button>);
+  await userEvent.click(screen.getByRole("button", { name: "Activate audio" }));
+  await Promise.all([inputContext.resume(), processorContext.resume()]);
+
+  const levels = await message;
+
+  expect(levels.rms).toBeGreaterThan(0);
+  expect(levels.peak).toBeGreaterThan(0);
+
+  oscillator.stop();
+  await inputContext.close();
+  await processorContext.close();
 });

--- a/packages/react-user-media/src/hooks/use-media-audio-processor.spec.tsx
+++ b/packages/react-user-media/src/hooks/use-media-audio-processor.spec.tsx
@@ -1,0 +1,157 @@
+import "@testing-library/jest-dom";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { useMediaAudioProcessor } from "./use-media-audio-processor";
+
+class MockPort extends EventTarget {
+  readonly messages: unknown[] = [];
+  closed = false;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  postMessage(message: unknown) {
+    this.messages.push(message);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  emit(message: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: message }));
+  }
+}
+
+class MockNode {
+  readonly port = new MockPort();
+  disconnected = false;
+
+  connect = vi.fn();
+
+  disconnect = vi.fn(() => {
+    this.disconnected = true;
+  });
+}
+
+class MockAudioContext {
+  readonly audioWorklet = {
+    addModule: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  };
+  readonly destination = new MockNode();
+  readonly source = new MockNode();
+  readonly gain = new MockNode() as MockNode & { gain: { value: number } };
+  close = vi.fn<() => Promise<void>>().mockResolvedValue();
+  resume = vi.fn<() => Promise<void>>().mockResolvedValue();
+
+  constructor() {
+    this.gain.gain = { value: 1 };
+  }
+
+  createMediaStreamSource = vi.fn(() => this.source);
+  createGain = vi.fn(() => this.gain);
+}
+
+function AudioProcessorHarness({
+  media,
+  context,
+}: {
+  media: MediaStream;
+  context: MockAudioContext;
+}) {
+  const processor = useMediaAudioProcessor({
+    strategy: "worklet",
+    createAudioContext: () => context as unknown as AudioContext,
+    workletModuleUrl: "https://example.test/level-meter.js",
+  });
+
+  return (
+    <>
+      <button onClick={() => processor.start(media)}>start</button>
+      <button onClick={() => processor.stop()}>stop</button>
+      <output data-testid="state">
+        {processor.isError
+          ? "error"
+          : processor.isLoading
+            ? "loading"
+            : processor.isReady
+              ? "ready"
+              : "idle"}
+      </output>
+      <output data-testid="rms">{processor.result?.rms ?? "none"}</output>
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+test("reports a module-loading failure as an error", async () => {
+  const context = new MockAudioContext();
+  context.audioWorklet.addModule.mockRejectedValueOnce(
+    new Error("module failed"),
+  );
+  vi.stubGlobal("AudioWorkletNode", MockNode);
+
+  render(<AudioProcessorHarness context={context} media={new MediaStream()} />);
+
+  await act(async () => {
+    screen.getByRole("button", { name: "start" }).click();
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("error");
+  });
+  expect(context.close).toHaveBeenCalledOnce();
+});
+
+test("tears down the graph without stopping supplied tracks", async () => {
+  const context = new MockAudioContext();
+  const stop = vi.fn();
+  const media = {
+    getTracks: () => [{ stop }],
+  } as unknown as MediaStream;
+  vi.stubGlobal("AudioWorkletNode", MockNode);
+
+  render(<AudioProcessorHarness context={context} media={media} />);
+
+  await act(async () => {
+    screen.getByRole("button", { name: "start" }).click();
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("ready");
+  });
+
+  await act(async () => {
+    screen.getByRole("button", { name: "stop" }).click();
+  });
+
+  expect(context.source.disconnect).toHaveBeenCalledOnce();
+  expect(context.gain.disconnect).toHaveBeenCalledOnce();
+  expect(context.close).toHaveBeenCalledOnce();
+  expect(stop).not.toHaveBeenCalled();
+});
+
+test("exposes worklet level messages while its session is current", async () => {
+  const context = new MockAudioContext();
+  vi.stubGlobal("AudioWorkletNode", MockNode);
+
+  render(<AudioProcessorHarness context={context} media={new MediaStream()} />);
+
+  await act(async () => {
+    screen.getByRole("button", { name: "start" }).click();
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("state")).toHaveTextContent("ready");
+  });
+
+  await act(async () => {
+    context.source.connect.mock.calls[0]?.[0].port.emit({
+      rms: 0.25,
+      peak: 0.5,
+      timestamp: 1,
+    });
+  });
+
+  expect(screen.getByTestId("rms")).toHaveTextContent("0.25");
+});

--- a/packages/react-user-media/src/hooks/use-media-audio-processor.ts
+++ b/packages/react-user-media/src/hooks/use-media-audio-processor.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  AudioProcessorState,
+  AudioProcessResult,
+  MediaAudioProcessorOptions,
+} from "../audio";
+import { getLevelMeterWorkletModuleUrl } from "../audio-worklet";
+import type { ShallowShapeOf } from "../types";
+
+interface WorkletGraph {
+  readonly context: AudioContext;
+  readonly source: MediaStreamAudioSourceNode;
+  readonly processor: AudioWorkletNode;
+  readonly silentGain: GainNode;
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function disposeGraph(graph: WorkletGraph | undefined) {
+  if (!graph) {
+    return;
+  }
+
+  graph.processor.port.onmessage = null;
+  graph.processor.port.close();
+  graph.source.disconnect();
+  graph.processor.disconnect();
+  graph.silentGain.disconnect();
+  void graph.context.close();
+}
+
+/**
+ * Connects an existing MediaStream to the built-in, realtime AudioWorklet
+ * level meter. It never obtains media or stops caller-owned stream tracks.
+ */
+export function useMediaAudioProcessor(
+  options: MediaAudioProcessorOptions,
+): AudioProcessorState {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [result, setResult] = useState<AudioProcessResult | null>(null);
+  const sessionId = useRef(0);
+  const graphRef = useRef<WorkletGraph | undefined>(undefined);
+
+  const stop = useCallback(function stopAudioProcessor() {
+    sessionId.current += 1;
+    disposeGraph(graphRef.current);
+    graphRef.current = undefined;
+    setIsLoading(false);
+    setIsReady(false);
+    setError(null);
+    setResult(null);
+  }, []);
+
+  const start = useCallback(
+    function startAudioProcessor(media: MediaStream) {
+      const currentSessionId = sessionId.current + 1;
+      sessionId.current = currentSessionId;
+      disposeGraph(graphRef.current);
+      graphRef.current = undefined;
+      setIsLoading(true);
+      setIsReady(false);
+      setError(null);
+      setResult(null);
+
+      void (async () => {
+        let graph: WorkletGraph | undefined;
+        let context: AudioContext | undefined;
+
+        try {
+          context = options.createAudioContext?.() ?? new AudioContext();
+          const moduleUrl =
+            options.workletModuleUrl ?? getLevelMeterWorkletModuleUrl();
+          await context.audioWorklet.addModule(moduleUrl);
+          await context.resume();
+
+          const source = context.createMediaStreamSource(media);
+          const processor = new AudioWorkletNode(
+            context,
+            "react-user-media-level-meter",
+          );
+          const silentGain = context.createGain();
+          silentGain.gain.value = 0;
+          source.connect(processor);
+          processor.connect(silentGain);
+          silentGain.connect(context.destination);
+
+          graph = { context, source, processor, silentGain };
+          processor.port.onmessage = (
+            event: MessageEvent<AudioProcessResult>,
+          ) => {
+            if (sessionId.current === currentSessionId) {
+              setResult(event.data);
+            }
+          };
+
+          if (sessionId.current !== currentSessionId) {
+            disposeGraph(graph);
+            return;
+          }
+
+          graphRef.current = graph;
+          setIsReady(true);
+        } catch (cause) {
+          disposeGraph(graph);
+          if (!graph) {
+            void context?.close();
+          }
+          if (sessionId.current === currentSessionId) {
+            setError(toError(cause));
+          }
+        } finally {
+          if (sessionId.current === currentSessionId) {
+            setIsLoading(false);
+          }
+        }
+      })();
+    },
+    [options],
+  );
+
+  useEffect(function disposeAudioProcessorOnUnmount() {
+    return function teardownAudioProcessor() {
+      sessionId.current += 1;
+      disposeGraph(graphRef.current);
+      graphRef.current = undefined;
+    };
+  }, []);
+
+  const state = useMemo(
+    () =>
+      ({
+        isLoading,
+        isReady,
+        isError: error !== null,
+        error,
+        result,
+        start,
+        stop,
+      }) satisfies ShallowShapeOf<AudioProcessorState>,
+    [error, isLoading, isReady, result, start, stop],
+  );
+
+  return state as AudioProcessorState;
+}

--- a/packages/react-user-media/src/index.ts
+++ b/packages/react-user-media/src/index.ts
@@ -1,3 +1,15 @@
+export type {
+  AudioFrame,
+  AudioProcessingStrategy,
+  AudioProcessOptions,
+  AudioProcessorErrorState,
+  AudioProcessorIdleState,
+  AudioProcessorLoadingState,
+  AudioProcessorReadyState,
+  AudioProcessorState,
+  AudioProcessResult,
+  MediaAudioProcessorOptions,
+} from "./audio";
 export * from "./close-media";
 export * from "./components";
 export * from "./hooks";

--- a/packages/react-user-media/tsconfig.types.json
+++ b/packages/react-user-media/tsconfig.types.json
@@ -4,6 +4,9 @@
     "outDir": "./dist/types",
     "declaration": true,
     "declarationMap": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
## Summary
- add shared audio processing contracts and ESM worklet packaging
- add a synchronous, throttled RMS/peak AudioWorklet processor and lifecycle-safe React hook
- document strategy selection and include a live level-meter example

## Test plan
- [x] `pnpm --filter @bengreenier/react-user-media test`
- [x] `pnpm lint`
- [x] `pnpm --filter @bengreenier/react-user-media build`
- [x] `pnpm --filter examples build`

Made with [Cursor](https://cursor.com)